### PR TITLE
style: fix ion-input element height for facsimile page nr inputs

### DIFF
--- a/src/theme/ionic/_ion-input.scss
+++ b/src/theme/ionic/_ion-input.scss
@@ -18,7 +18,7 @@ ion-input.image-nr-input.input-fill-solid {
             width: 4.375rem;
             flex-grow: 0;
             flex-basis: auto;
-            padding: 5px 8px;
+            padding: 8px;
             border: 1px solid #666;
             margin: 8px 0;
             border-radius: 3px;


### PR DESCRIPTION
Fixes the reduced height of the ion-input element introduced in Ionic 7.6.0 for the facsimile page number inputs.