### PR TITLE
refactor: get doodle illustrations from backend using media collection mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Doodle illustrations must be placed in a media collection in the backend rather than in the hard coded `src/assets/images/verk/` folder in the frontend. Use `collections.mediaCollectionMappings` in `config.ts` to map the id of the collection with doodles to the id of the media collection that holds the images in the backend.
+
 ## [1.0.1] – 2023-12-07
 
 ### Added

--- a/src/assets/config/config.ts
+++ b/src/assets/config/config.ts
@@ -53,7 +53,7 @@ export const config: Config = {
     },
     highlightSearchMatches: true,
     inlineIllustrations: [206],
-    mediaCollectionMappings: { 214: 44, 206: 19 },
+    mediaCollectionMappings: { 214: 44, 206: 19, 218: 19 },
     order: [
       [216, 219, 220, 218, 210, 208, 207, 214, 203, 213,
         202, 199, 221, 206, 201, 211, 200, 205, 215, 217,


### PR DESCRIPTION
Previously doodle illustrations had to be in the frontend in the path src/assets/images/verk/, now they must be in the backend. Use collections.mediaCollectionMappings in config.ts to map the id of the collection with doodles to the id of the media collection that holds the images in the backend.