### PR TITLE
refactor: limit image path fixing in collection components to src attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Doodle illustrations must be placed in a media collection in the backend rather than in the hard coded `src/assets/images/verk/` folder in the frontend. Use `collections.mediaCollectionMappings` in `config.ts` to map the id of the collection with doodles to the id of the media collection that holds the images in the backend.
 - Illustration image path mapping to media collections is performed solely based on the presence of the CSS class name `est_figure_graphic` on `img` elements – not as previously based on the image `src` containing `assets/images/verk/` in it. Thus, illustration images that are to be mapped to media collections must have just the image file names in the `src` attributes, rather than `images/verk/<filename>` as previously. Images with absolute URLs in `src` are never mapped regardless of class names.
+- Fixing image paths in collection pages from `images/` to `assets/images/` is done specifically at the start of `src` attribute values – not for any occurrence of the string `images/`.
 
 ## [1.0.1] – 2023-12-07
 
@@ -24,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update Angular to 17.0.6. ([bf878ae](https://github.com/slsfi/digital-edition-frontend-ng/commit/bf878aeeeb7a6100b81f4e1e808e7913806ec5b8))
 - Apply background colors to toggle labels only instead of the entire toggles in the view options popover. ([fc2fc38](https://github.com/slsfi/digital-edition-frontend-ng/commit/fc2fc38c64d3c4d66c2838769f9cac74f0a72a08))
 - Adjust padding of facsimile page number input elements to accommodate changed spec in Ionic 7.6.0. ([34d1ab0](https://github.com/slsfi/digital-edition-frontend-ng/commit/34d1ab074e03d386f01e6fe00e1fe5e0409dcfb5))
-- Moved inline styles for checkbox labels on the elastic-search page to the component SCSS-file. ([8d0a766](https://github.com/slsfi/digital-edition-frontend-ng/commit/8d0a76692396c77715fa570ac32e8f19bfd6b41a))
+- Move inline styles for checkbox labels on the elastic-search page to the component SCSS-file. ([8d0a766](https://github.com/slsfi/digital-edition-frontend-ng/commit/8d0a76692396c77715fa570ac32e8f19bfd6b41a))
 
 ## [1.0.0] – 2023-12-05
 

--- a/src/app/components/collection-text-types/facsimiles/facsimiles.component.ts
+++ b/src/app/components/collection-text-types/facsimiles/facsimiles.component.ts
@@ -162,7 +162,7 @@ export class FacsimilesComponent implements OnInit {
     this.facsURLDefault = config.app.backendBaseURL + '/' + config.app.projectNameDB +
           `/facsimiles/${facs.publication_facsimile_collection_id}/`;
     this.text = this.sanitizer.bypassSecurityTrustHtml(
-      facs.content?.replace(/images\//g, 'assets/images/')
+      facs.content?.replace(/src="images\//g, 'src="assets/images/')
     );
 
     if (extImageNr !== undefined) {

--- a/src/app/components/collection-text-types/variants/variants.component.ts
+++ b/src/app/components/collection-text-types/variants/variants.component.ts
@@ -112,7 +112,7 @@ export class VariantsComponent implements OnInit {
   postprocessVariantText(text: string) {
     text = text.trim();
     // Fix image paths
-    text = text.replace(/images\//g, 'assets/images/');
+    text = text.replace(/src="images\//g, 'src="assets/images/');
     // Add "tei" and "teiVariant" to all classlists
     text = text.replace(
       /class=\"([a-z A-Z _ 0-9]{1,140})\"/g,

--- a/src/app/dialogs/modals/download-texts/download-texts.modal.ts
+++ b/src/app/dialogs/modals/download-texts/download-texts.modal.ts
@@ -423,7 +423,7 @@ export class DownloadTextsModal implements OnDestroy, OnInit {
   }
 
   private getProcessedPrintIntro(text: string): string {
-    text = text.replace(/images\//g, 'assets/images/');
+    text = text.replace(/src="images\//g, 'src="assets/images/');
     text = this.fixImagePaths(text);
     return this.constructHtmlForPrint(text, 'intro');
   }
@@ -911,8 +911,8 @@ export class DownloadTextsModal implements OnDestroy, OnInit {
   private fixImagePaths(text: string): string {
     // fix image paths
     return text.replace(
-      /assets\/images\//g,
-      (this.document.defaultView?.location.origin ?? '')
+      /src="assets\/images\//g,
+      'src="' + (this.document.defaultView?.location.origin ?? '')
             + (this.document.defaultView?.location.pathname.split('/')[1] === this.activeLocale ? '/' + this.activeLocale : '')
             + '/assets/images/'
     );

--- a/src/app/pages/collection/foreword/collection-foreword.page.ts
+++ b/src/app/pages/collection/foreword/collection-foreword.page.ts
@@ -86,7 +86,7 @@ export class CollectionForewordPage implements OnDestroy, OnInit {
     return this.collectionContentService.getForeword(id, lang).pipe(
       map((res: any) => {
         if (res?.content && res?.content !== 'File not found') {
-          let text = res.content.replace(/images\//g, 'assets/images/');
+          let text = res.content.replace(/src="images\//g, 'src="assets/images/');
           text = this.parserService.insertSearchMatchTags(text, this.searchMatches);
           return this.sanitizer.bypassSecurityTrustHtml(text);
         } else {

--- a/src/app/pages/collection/introduction/collection-introduction.page.ts
+++ b/src/app/pages/collection/introduction/collection-introduction.page.ts
@@ -191,7 +191,7 @@ export class CollectionIntroductionPage implements OnInit, OnDestroy {
         if (res?.content) {
           this.textLoading = false;
           // Fix paths for images and file extensions for icons
-          let textContent = res.content.replace(/images\//g, 'assets/images/');
+          let textContent = res.content.replace(/src="images\//g, 'src="assets/images/');
 
           // TODO: this manipulation of the introductions TOC should maybe be done using htmlparser2,
           // TODO: on the other hand using regex doesn't rely on an external dependency ...

--- a/src/app/pages/collection/title/collection-title.page.ts
+++ b/src/app/pages/collection/title/collection-title.page.ts
@@ -92,7 +92,7 @@ export class CollectionTitlePage implements OnDestroy, OnInit {
       return this.collectionContentService.getTitle(id, lang).pipe(
         map((res: any) => {
           if (res?.content) {
-            let text = res.content.replace(/images\//g, 'assets/images/');
+            let text = res.content.replace(/src="images\//g, 'src="assets/images/');
             text = this.parserService.insertSearchMatchTags(text, this.searchMatches);
             return this.sanitizer.bypassSecurityTrustHtml(text);
           } else {

--- a/src/app/services/comment.service.ts
+++ b/src/app/services/comment.service.ts
@@ -125,7 +125,7 @@ export class CommentService {
 
   private postprocessCommentsText(text: string): string {
     // Fix image paths
-    text = text.replace(/images\//g, 'assets/images/');
+    text = text.replace(/src="images\//g, 'src="assets/images/');
     // Add "teiComment" to all classlists
     text = text.replace(
       /class=\"([a-z A-Z _ 0-9]{1,140})\"/g,

--- a/src/app/services/html-parser.service.ts
+++ b/src/app/services/html-parser.service.ts
@@ -7,7 +7,6 @@ import { render } from 'dom-serializer';
 
 import { config } from '@config';
 import { CollectionContentService } from '@services/collection-content.service';
-import { isEmptyObject } from '@utility-functions';
 
 
 @Injectable({
@@ -29,7 +28,7 @@ export class HtmlParserService {
   postprocessReadingText(text: string, collectionId: string) {
     text = text.trim();
     // Fix image paths
-    text = text.replace(/images\//g, 'assets/images/');
+    text = text.replace(/src="images\//g, 'src="assets/images/');
     // Map illustration image paths to backend media paths
     text = this.mapIllustrationImagePaths(text, collectionId);
     // Add "tei" class to all classlists
@@ -43,7 +42,7 @@ export class HtmlParserService {
   postprocessManuscriptText(text: string) {
     text = text.trim();
     // Fix image paths
-    text = text.replace(/images\//g, 'assets/images/');
+    text = text.replace(/src="images\//g, 'src="assets/images/');
     // Add "tei" and "teiManuscript" to all classlists
     text = text.replace(
       /class=\"([a-z A-Z _ 0-9]{1,140})\"/g,


### PR DESCRIPTION
Fixing image paths in collection pages from `images/` to `assets/images/` is done specifically at the start of `src` attribute values – not for any occurrence of the string `images/`.