### PR TITLE
fix: remove incomplete regex sanitization of script tags in search query results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Remove incomplete regex sanitization of script tags in search query results. The regex sanitization is unnecessary because the query results are anyway parsed as HTML, only text nodes are retained and the `<`, `>` characters are converted to their corresponding HTML entities.
+- Remove incomplete regex sanitization of script tags in search query results. The regex sanitization is unnecessary because the query results are anyway parsed as HTML, only text nodes are retained and any `<`, `>` characters are converted to their corresponding HTML entities.
 
 ## [1.0.2] – 2023-12-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove incomplete regex sanitization of script tags in search query results. The regex sanitization is unnecessary because the query results are anyway parsed as HTML, only text nodes are retained and the `<`, `>` characters are converted to their corresponding HTML entities.
+
 ## [1.0.2] – 2023-12-11
 
 ### Changed

--- a/src/app/services/html-parser.service.ts
+++ b/src/app/services/html-parser.service.ts
@@ -223,8 +223,8 @@ export class HtmlParserService {
       queryMatches.forEach((term: any) => {
         // Remove line break characters
         let decoded_match = term.replace(/\n/gm, '');
-        // Remove any script tags
-        decoded_match = decoded_match.replace(/<script.+?<\/script>/gi, '');
+        // Encode some character entities in match, also sanitizes the match
+        // since it’s parsed as html and only text nodes are retained.
         decoded_match = this.encodeSelectedCharEntities(decoded_match);
         matches.push(decoded_match);
       });

--- a/src/app/services/html-parser.service.ts
+++ b/src/app/services/html-parser.service.ts
@@ -223,8 +223,10 @@ export class HtmlParserService {
       queryMatches.forEach((term: any) => {
         // Remove line break characters
         let decoded_match = term.replace(/\n/gm, '');
-        // Encode some character entities in match, also sanitizes the match
-        // since it’s parsed as html and only text nodes are retained.
+        // Encode selected character entities in match (also sanitizes the
+        // match since it’s parsed as html, only text nodes are retained
+        // and the `<`, `>` characters are converted to their corresponding
+        // HTML entities).
         decoded_match = this.encodeSelectedCharEntities(decoded_match);
         matches.push(decoded_match);
       });


### PR DESCRIPTION
The regex sanitization is unnecessary because the query results are anyway parsed as HTML, only text nodes are retained and any `<`, `>` characters are converted to their corresponding HTML entities.