### PR TITLE
build: change base app Docker image in compose.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Base app Docker image repository and tag in `compose.yml`.
+
 ### Fixed
 
 - Remove incomplete regex sanitization of script tags in search query results. The regex sanitization is unnecessary because the query results are anyway parsed as HTML, only text nodes are retained and any `<`, `>` characters are converted to their corresponding HTML entities.

--- a/compose.yml
+++ b/compose.yml
@@ -8,6 +8,6 @@ services:
       - "api.sls.fi:172.16.2.136"
       - "granska-api.sls.fi:172.16.2.136"
       - "testa-vonwright.sls.fi:172.16.2.136"
-    image: docker.io/slsfinland/digital-edition-frontend-ng:latest
+    image: ghcr.io/slsfi/digital-edition-frontend-ng:main
     ports:
       - 2089:4201


### PR DESCRIPTION
The Docker images for the base app are no longer built by and stored in DockerHub, but GitHub using actions.