### PR TITLE
feature: add config option to replace image assets paths in collection texts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Config option to show or hide the toggle for switching between the normalized and non-normalized version of manuscripts: `config.component.manuscripts.showNormalizedToggle`. The new config option defaults to `true`.
+- Config option to show or hide the toggle for switching between the normalized and non-normalized version of manuscripts: `config.component.manuscripts.showNormalizedToggle`. The new config option defaults to `true`, which corresponds to the old behaviour.
 - Config option to add mandatory TEI class names to collection text HTML loaded from the backend: `config.collections.addTEIClassNames`. The new config option defaults to `true`, which corresponds to the old behaviour. If set to `false`, the class attributes of all HTML elements in reading texts and manuscripts fetched from the backend, must contain the value `tei`. In addition, elements in manuscripts also must contain the class name `teiManuscript`. Otherwise, some inherent functionality and styles won’t work anymore for these texts. Setting the new config option to `false` improves app performance.
+- Config option to fix paths to the `assets/images/` folder in collection texts: `config.collections.replaceImageAssetsPaths`. The new config option defaults to `true`, which corresponds to the old behaviour. When this option is `true`, `src` attribute values starting with `images/` in the HTML of collection texts are replaced with `assets/images/`, which is the correct path to the image assets folder. Setting the new config option to `false` improves app performance.
 
 ### Changed
 

--- a/src/app/components/collection-text-types/facsimiles/facsimiles.component.ts
+++ b/src/app/components/collection-text-types/facsimiles/facsimiles.component.ts
@@ -39,6 +39,7 @@ export class FacsimilesComponent implements OnInit {
   numberOfImages: number = 0;
   prevX: number = 0;
   prevY: number = 0;
+  replaceImageAssetsPaths: boolean = true;
   selectedFacsimile: any | null = null;
   selectedFacsimileIsExternal: boolean = false;
   showTitle: boolean = true;
@@ -54,6 +55,7 @@ export class FacsimilesComponent implements OnInit {
   ) {
     this.facsSize = config.component?.facsimiles?.imageQuality ?? 1;
     this.facsURLAlternate = config.app?.alternateFacsimileBaseURL ?? '';
+    this.replaceImageAssetsPaths = config.collections?.replaceImageAssetsPaths ?? true;
     this.showTitle = config.component?.facsimiles?.showTitle ?? true;
   }
 
@@ -161,9 +163,10 @@ export class FacsimilesComponent implements OnInit {
     this.numberOfImages = facs.number_of_pages;
     this.facsURLDefault = config.app.backendBaseURL + '/' + config.app.projectNameDB +
           `/facsimiles/${facs.publication_facsimile_collection_id}/`;
-    this.text = this.sanitizer.bypassSecurityTrustHtml(
-      facs.content?.replace(/src="images\//g, 'src="assets/images/')
-    );
+    const facsText = this.replaceImageAssetsPaths
+      ? facs.content?.replace(/src="images\//g, 'src="assets/images/')
+      : facs.content;
+    this.text = this.sanitizer.bypassSecurityTrustHtml(facsText);
 
     if (extImageNr !== undefined) {
       this.facsNumber = extImageNr;

--- a/src/app/components/collection-text-types/variants/variants.component.ts
+++ b/src/app/components/collection-text-types/variants/variants.component.ts
@@ -103,22 +103,10 @@ export class VariantsComponent implements OnInit {
       this.emitOutputValues(this.selectedVariant);
     }
     if (this.selectedVariant) {
-      let text = this.postprocessVariantText(this.selectedVariant.content);
+      let text = this.parserService.postprocessVariantText(this.selectedVariant.content);
       text = this.parserService.insertSearchMatchTags(text, this.searchMatches);
       this.text = this.sanitizer.bypassSecurityTrustHtml(text);
     }
-  }
-
-  postprocessVariantText(text: string) {
-    text = text.trim();
-    // Fix image paths
-    text = text.replace(/src="images\//g, 'src="assets/images/');
-    // Add "tei" and "teiVariant" to all classlists
-    text = text.replace(
-      /class=\"([a-z A-Z _ 0-9]{1,140})\"/g,
-      'class=\"teiVariant tei $1\"'
-    );
-    return text;
   }
 
   async selectVariant(event: any) {

--- a/src/app/dialogs/modals/download-texts/download-texts.modal.ts
+++ b/src/app/dialogs/modals/download-texts/download-texts.modal.ts
@@ -57,6 +57,7 @@ export class DownloadTextsModal implements OnDestroy, OnInit {
   publicationData$: Observable<any>;
   publicationTitle: string = '';
   readTextsMode: boolean = false;
+  replaceImageAssetsPaths: boolean = true;
   showLoadingError: boolean = false;
   showMissingTextError: boolean = false;
   showPrintError: boolean = false;
@@ -132,6 +133,8 @@ export class DownloadTextsModal implements OnDestroy, OnInit {
     this.downloadFormatsMs.length && this.downloadFormatsMs.push(
       this.downloadFormatsMs.splice(this.downloadFormatsMs.indexOf('print'), 1)[0]
     );
+
+    this.replaceImageAssetsPaths = config.collections?.replaceImageAssetsPaths ?? true;
   }
 
   ngOnInit(): void {
@@ -423,7 +426,9 @@ export class DownloadTextsModal implements OnDestroy, OnInit {
   }
 
   private getProcessedPrintIntro(text: string): string {
-    text = text.replace(/src="images\//g, 'src="assets/images/');
+    if (this.replaceImageAssetsPaths) {
+      text = text.replace(/src="images\//g, 'src="assets/images/');
+    }
     text = this.fixImagePaths(text);
     return this.constructHtmlForPrint(text, 'intro');
   }

--- a/src/app/pages/collection/foreword/collection-foreword.page.ts
+++ b/src/app/pages/collection/foreword/collection-foreword.page.ts
@@ -24,6 +24,7 @@ export class CollectionForewordPage implements OnDestroy, OnInit {
   collectionID: string = '';
   intervalTimerId: number = 0;
   mobileMode: boolean = false;
+  replaceImageAssetsPaths: boolean = true;
   searchMatches: string[] = [];
   showURNButton: boolean = false;
   showViewOptionsButton: boolean = true;
@@ -46,6 +47,7 @@ export class CollectionForewordPage implements OnDestroy, OnInit {
     private viewOptionsService: ViewOptionsService,
     @Inject(LOCALE_ID) private activeLocale: string
   ) {
+    this.replaceImageAssetsPaths = config.collections?.replaceImageAssetsPaths ?? true;
     this.showURNButton = config.page?.foreword?.showURNButton ?? false;
     this.showViewOptionsButton = config.page?.foreword?.showViewOptionsButton ?? true;
   }
@@ -86,7 +88,9 @@ export class CollectionForewordPage implements OnDestroy, OnInit {
     return this.collectionContentService.getForeword(id, lang).pipe(
       map((res: any) => {
         if (res?.content && res?.content !== 'File not found') {
-          let text = res.content.replace(/src="images\//g, 'src="assets/images/');
+          let text = this.replaceImageAssetsPaths
+            ? res.content.replace(/src="images\//g, 'src="assets/images/')
+            : res.content;
           text = this.parserService.insertSearchMatchTags(text, this.searchMatches);
           return this.sanitizer.bypassSecurityTrustHtml(text);
         } else {

--- a/src/app/pages/collection/introduction/collection-introduction.page.ts
+++ b/src/app/pages/collection/introduction/collection-introduction.page.ts
@@ -42,6 +42,7 @@ export class CollectionIntroductionPage implements OnInit, OnDestroy {
   intervalTimerId: number = 0;
   mobileMode: boolean = false;
   pos: string | null = null;
+  replaceImageAssetsPaths: boolean = true;
   searchMatches: string[] = [];
   showTextDownloadButton: boolean = false;
   showURNButton: boolean = true;
@@ -92,6 +93,7 @@ export class CollectionIntroductionPage implements OnInit, OnDestroy {
     @Inject(LOCALE_ID) private activeLocale: string
   ) {
     this.hasSeparateIntroToc = config.page?.introduction?.hasSeparateTOC ?? false;
+    this.replaceImageAssetsPaths = config.collections?.replaceImageAssetsPaths ?? true;
     this.showTextDownloadButton = config.page?.introduction?.showTextDownloadButton ?? false;
     this.showURNButton = config.page?.introduction?.showURNButton ?? true;
     this.showViewOptionsButton = config.page?.introduction?.showViewOptionsButton ?? true;
@@ -190,8 +192,10 @@ export class CollectionIntroductionPage implements OnInit, OnDestroy {
       next: (res: any) => {
         if (res?.content) {
           this.textLoading = false;
-          // Fix paths for images and file extensions for icons
-          let textContent = res.content.replace(/src="images\//g, 'src="assets/images/');
+          // Fix paths for images
+          let textContent = this.replaceImageAssetsPaths
+            ? res.content.replace(/src="images\//g, 'src="assets/images/')
+            : res.content;
 
           // TODO: this manipulation of the introductions TOC should maybe be done using htmlparser2,
           // TODO: on the other hand using regex doesn't rely on an external dependency ...

--- a/src/app/pages/collection/title/collection-title.page.ts
+++ b/src/app/pages/collection/title/collection-title.page.ts
@@ -27,6 +27,7 @@ export class CollectionTitlePage implements OnDestroy, OnInit {
   intervalTimerId: number = 0;
   loadContentFromMarkdown: boolean = false;
   mobileMode: boolean = false;
+  replaceImageAssetsPaths: boolean = true;
   searchMatches: string[] = [];
   showURNButton: boolean = false;
   showViewOptionsButton: boolean = true;
@@ -51,6 +52,7 @@ export class CollectionTitlePage implements OnDestroy, OnInit {
     @Inject(LOCALE_ID) private activeLocale: string
   ) {
     this.loadContentFromMarkdown = config.page?.title?.loadContentFromMarkdown ?? false;
+    this.replaceImageAssetsPaths = config.collections?.replaceImageAssetsPaths ?? true;
     this.showURNButton = config.page?.title?.showURNButton ?? false;
     this.showViewOptionsButton = config.page?.title?.showViewOptionsButton ?? true;
   }
@@ -92,7 +94,9 @@ export class CollectionTitlePage implements OnDestroy, OnInit {
       return this.collectionContentService.getTitle(id, lang).pipe(
         map((res: any) => {
           if (res?.content) {
-            let text = res.content.replace(/src="images\//g, 'src="assets/images/');
+            let text = this.replaceImageAssetsPaths
+              ? res.content.replace(/src="images\//g, 'src="assets/images/')
+              : res.content;
             text = this.parserService.insertSearchMatchTags(text, this.searchMatches);
             return this.sanitizer.bypassSecurityTrustHtml(text);
           } else {

--- a/src/app/services/comment.service.ts
+++ b/src/app/services/comment.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { catchError, map, Observable, of, switchMap, tap } from 'rxjs';
+import { catchError, map, Observable, of } from 'rxjs';
 
 import { config } from '@config';
 
@@ -11,6 +11,7 @@ import { config } from '@config';
 export class CommentService {
   private apiURL: string = '';
   private cachedCollectionComments: Record<string, any> = {};
+  private replaceImageAssetsPaths: boolean = true;
 
   constructor(
     private http: HttpClient
@@ -18,6 +19,7 @@ export class CommentService {
     const apiBaseURL = config.app?.backendBaseURL ?? '';
     const projectName = config.app?.projectNameDB ?? '';
     this.apiURL = apiBaseURL + '/' + projectName;
+    this.replaceImageAssetsPaths = config.collections?.replaceImageAssetsPaths ?? true;
   }
 
   /**
@@ -124,8 +126,10 @@ export class CommentService {
   }
 
   private postprocessCommentsText(text: string): string {
-    // Fix image paths
-    text = text.replace(/src="images\//g, 'src="assets/images/');
+    // Fix image paths if config option for this enabled
+    if (this.replaceImageAssetsPaths) {
+      text = text.replace(/src="images\//g, 'src="assets/images/');
+    }
     // Add "teiComment" to all classlists
     text = text.replace(
       /class=\"([a-z A-Z _ 0-9]{1,140})\"/g,

--- a/src/app/services/html-parser.service.ts
+++ b/src/app/services/html-parser.service.ts
@@ -16,6 +16,7 @@ export class HtmlParserService {
   private addTEIClassNames: boolean = true;
   private apiURL: string = '';
   private mediaCollectionMappings: any = {};
+  private replaceImageAssetsPaths: boolean = true;
 
   constructor(
     private collectionContentService: CollectionContentService
@@ -25,12 +26,13 @@ export class HtmlParserService {
     this.apiURL = apiBaseURL + '/' + projectName;
     this.mediaCollectionMappings = config.collections?.mediaCollectionMappings ?? {};
     this.addTEIClassNames = config.collections?.addTEIClassNames ?? true;
+    this.replaceImageAssetsPaths = config.collections?.replaceImageAssetsPaths ?? true;
   }
 
-  postprocessReadingText(text: string, collectionId: string) {
+  postprocessReadingText(text: string, collectionId: string): string {
     text = text.trim();
-    // Fix image paths
-    text = text.replace(/src="images\//g, 'src="assets/images/');
+    // Fix image paths if config option for this enabled
+    text = this.fixImageAssetsPaths(text);
     // Map illustration image paths to backend media paths
     text = this.mapIllustrationImagePaths(text, collectionId);
     // Add "tei" class to all classlists if config option for this enabled
@@ -43,10 +45,10 @@ export class HtmlParserService {
     return text;
   }
 
-  postprocessManuscriptText(text: string) {
+  postprocessManuscriptText(text: string): string {
     text = text.trim();
-    // Fix image paths
-    text = text.replace(/src="images\//g, 'src="assets/images/');
+    // Fix image paths if config option for this enabled
+    text = this.fixImageAssetsPaths(text);
     // Add "tei" and "teiManuscript" to all classlists if config option for this enabled
     if (this.addTEIClassNames) {
       text = text.replace(
@@ -54,6 +56,18 @@ export class HtmlParserService {
         'class=\"teiManuscript tei $1\"'
       );
     }
+    return text;
+  }
+
+  postprocessVariantText(text: string): string {
+    text = text.trim();
+    // Fix image paths if config option for this enabled
+    text = this.fixImageAssetsPaths(text);
+    // Add "tei" and "teiVariant" to all classlists
+    text = text.replace(
+      /class=\"([a-z A-Z _ 0-9]{1,140})\"/g,
+      'class=\"teiVariant tei $1\"'
+    );
     return text;
   }
 
@@ -297,6 +311,15 @@ export class HtmlParserService {
     });
 
     return parsed_text;
+  }
+
+  private fixImageAssetsPaths(text: string): string {
+    // Fix image paths if config option for this enabled
+    if (this.replaceImageAssetsPaths) {
+      return text.replace(/src="images\//g, 'src="assets/images/');
+    } else {
+      return text;
+    }
   }
 
 }

--- a/src/assets/config/config.ts
+++ b/src/assets/config/config.ts
@@ -34,6 +34,7 @@ export const config: Config = {
   },
   collections: {
     addTEIClassNames: true,
+    replaceImageAssetsPaths: true,
     enableLegacyIDs: true,
     enableMathJax: false,
     firstTextItem: {


### PR DESCRIPTION
`config.collections.replaceImageAssetsPaths`.
The new config option defaults to `true`, which corresponds to the old behaviour. When this option is `true`, `src` attribute values starting with `images/` in the HTML of collection texts are replaced with `assets/images/`, which is the correct path to the image assets folder. Setting the new config option to `false` improves app performance.