### PR TITLE
Serve static files using nginx webserver in front of node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,9 @@ WORKDIR /digital-edition-frontend-ng
 
 # 2. Create intermediate build image, starting from base image.
 FROM base AS build
+# notify docker that static browser content will be a volume, so it can be used by nginx
+# the volume should automatically be populated with the correct files from the image on first docker compose up
+VOLUME [ "/digital-edition-frontend-ng/dist/app/browser" ]
 # Copy all files from the source folder to the
 # workdir in the container filesystem.
 COPY . .

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,15 @@
 services:
-  web:
+  nginx:
+    image: docker.io/library/nginx:1.25.3
+    depends_on:
+      - web
+    ports:
+      - 2089:80
     restart: unless-stopped
+    volumes:
+      - browser-static:/static
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf
+  web:
     build:
       context: .
       dockerfile: Dockerfile
@@ -9,5 +18,8 @@ services:
       - "granska-api.sls.fi:172.16.2.136"
       - "testa-vonwright.sls.fi:172.16.2.136"
     image: ghcr.io/slsfi/digital-edition-frontend-ng:main
-    ports:
-      - 2089:4201
+    restart: unless-stopped
+    volumes:
+      - browser-static:/digital-edition-frontend-ng/dist/app/browser
+volumes:
+  browser-static:

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,28 @@
+upstream nodejs {
+    server web:4201;
+}
+
+server {
+    listen 80;
+
+    root /static;
+
+    location / {
+        try_files $uri sv/$uri @backend;
+    }
+
+    location @backend {
+        proxy_pass http://nodejs;
+
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $http_host;
+        proxy_http_version 1.1;
+        proxy_set_header X-NginX-Proxy true;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_cache_bypass $http_upgrade;
+        proxy_redirect off;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}


### PR DESCRIPTION
This improves website performance under load by serving static content using nginx, which is more performant than node's express-server.

Furthermore, nginx's performance is not impacted by node being busy with server-side rendering tasks for dynamic content.