### PR TITLE
feature: define site logo dimensions in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- Config option to specify the dimensions of the site logo in the top menu: `config.component.topMenu.siteLogoDimensions`. The new config option is an object containing nested objects for specifying the height and width of the logo in both desktop and mobile mode. If the option is omitted, it defaults to an empty object, which corresponds to the old behaviour where the height and width attributes of the HTMLImageElement of the logo are not set. Setting the dimensions reduces layout shifts during page loading. Structure of the `siteLogoDimensions` with example values:
+
+```
+siteLogoDimensions: {
+  default: {
+    height: 56,
+    width: 173
+  },
+  mobile: {
+    height: 56,
+    width: 56
+  }
+}
+```
+
 ### Changed
 
 - Default site logo in top menu changed to optimized PNG image file. Added both black and white versions of SLS’s logo to `assets/images/logo/`.

--- a/src/app/components/menus/top/top-menu.component.html
+++ b/src/app/components/menus/top/top-menu.component.html
@@ -67,8 +67,22 @@
   </li>
   <li *ngIf="showSiteLogo" class="site-logo" role="menuitem">
     <a href="{{siteLogoLinkUrl}}">
-      <img *ngIf="siteLogoDefaultImageUrl" class="default-logo" alt="Logo" i18n-alt="@@TopMenu.LogoAltText" src="{{siteLogoDefaultImageUrl}}" loading="lazy">
-      <img *ngIf="siteLogoMobileImageUrl" class="mobile-logo" alt="Logo" i18n-alt="@@TopMenu.LogoAltText" src="{{siteLogoMobileImageUrl}}" loading="lazy">
+      <img *ngIf="siteLogoDefaultImageUrl"
+            class="default-logo"
+            alt="Logo"
+            i18n-alt="@@TopMenu.LogoAltText"
+            [attr.height]="siteLogoDimensions?.default?.height ? siteLogoDimensions.default.height : null"
+            [attr.width]="siteLogoDimensions?.default?.width ? siteLogoDimensions.default.width : null"
+            [src]="siteLogoDefaultImageUrl"
+      >
+      <img *ngIf="siteLogoMobileImageUrl"
+            class="mobile-logo"
+            alt="Logo"
+            i18n-alt="@@TopMenu.LogoAltText"
+            [attr.height]="siteLogoDimensions?.mobile?.height ? siteLogoDimensions.mobile.height : null"
+            [attr.width]="siteLogoDimensions?.mobile?.width ? siteLogoDimensions.mobile.width : null"
+            [src]="siteLogoMobileImageUrl"
+      >
     </a>
   </li>
 </ul>

--- a/src/app/components/menus/top/top-menu.component.ts
+++ b/src/app/components/menus/top/top-menu.component.ts
@@ -38,6 +38,7 @@ export class TopMenuComponent implements OnDestroy, OnInit {
   siteLogoDefaultImageUrl: string = 'assets/images/logo/SLS_logo_full_white_346x112.png';
   siteLogoLinkUrl: string = 'https://www.sls.fi/';
   siteLogoMobileImageUrl: string = 'assets/images/logo/SLS_logo_symbol_white_112x112.png';
+  siteLogoDimensions: any = {};
   _window: Window;
 
   constructor(
@@ -58,6 +59,7 @@ export class TopMenuComponent implements OnDestroy, OnInit {
     this.siteLogoLinkUrl = config.component?.topMenu?.siteLogoLinkURL ?? 'https://www.sls.fi/';
     this.siteLogoDefaultImageUrl = config.component?.topMenu?.siteLogoDefaultImageURL ?? 'assets/images/logo/SLS_logo_full_white_346x112.png';
     this.siteLogoMobileImageUrl = config.component?.topMenu?.siteLogoMobileImageURL ?? 'assets/images/logo/SLS_logo_symbol_white_112x112.png';
+    this.siteLogoDimensions = config.component?.topMenu?.siteLogoDimensions ?? {};
 
     if (!this.siteLogoMobileImageUrl && this.siteLogoDefaultImageUrl) {
       this.siteLogoMobileImageUrl = this.siteLogoDefaultImageUrl;

--- a/src/assets/config/config.ts
+++ b/src/assets/config/config.ts
@@ -342,7 +342,17 @@ export const config: Config = {
       showSiteLogo: true,
       siteLogoDefaultImageURL: "assets/images/logo/SLS_logo_full_white_346x112.png",
       siteLogoMobileImageURL: "assets/images/logo/SLS_logo_symbol_white_112x112.png",
-      siteLogoLinkURL: "https://www.sls.fi/"
+      siteLogoLinkURL: "https://www.sls.fi/",
+      siteLogoDimensions: {
+        default: {
+          height: 56,
+          width: 173
+        },
+        mobile: {
+          height: 56,
+          width: 56
+        }
+      }
     },
     variants: {
       showOpenLegendButton: true


### PR DESCRIPTION
Added config option to specify the dimensions of the site logo in the top menu: `config.component.topMenu.siteLogoDimensions`. The new config option is an object containing nested objects for specifying the height and width of the logo in both desktop and mobile mode. If the option is omitted, it defaults to an empty object, which corresponds to the old behaviour where the height and width attributes of the HTMLImageElement of the logo are not set. Setting the dimensions reduces layout shifts during page loading. Structure of the `siteLogoDimensions` with example values:

```
siteLogoDimensions: {
  default: {
    height: 56,
    width: 173
  },
  mobile: {
    height: 56,
    width: 56
  }
}
```