### PR TITLE
build(deps): move @angular/compiler to production dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - Update htmlparser2 to 9.1.0.
 - Update marked to 11.1.1 and remove @types/marked. Move markdown parsing to function in MarkdownContentService.
 - Update zone.js to 0.14.3.
+- Moved @angular/compiler from devDependencies to dependencies (like in fresh Angular 17 apps).
 - Update typescript to 5.3.3.
 - Update @types/node to 20.11.5.
 - Update browser-sync to 3.0.2.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@angular/animations": "^17.1.0",
         "@angular/common": "^17.1.0",
+        "@angular/compiler": "^17.1.0",
         "@angular/core": "^17.1.0",
         "@angular/forms": "^17.1.0",
         "@angular/platform-browser": "^17.1.0",
@@ -34,7 +35,6 @@
       "devDependencies": {
         "@angular-devkit/build-angular": "^17.1.0",
         "@angular/cli": "^17.1.0",
-        "@angular/compiler": "^17.1.0",
         "@angular/compiler-cli": "^17.1.0",
         "@angular/language-service": "^17.1.0",
         "@angular/localize": "^17.1.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@angular/animations": "^17.1.0",
     "@angular/common": "^17.1.0",
+    "@angular/compiler": "^17.1.0",
     "@angular/core": "^17.1.0",
     "@angular/forms": "^17.1.0",
     "@angular/platform-browser": "^17.1.0",
@@ -43,7 +44,6 @@
   "devDependencies": {
     "@angular-devkit/build-angular": "^17.1.0",
     "@angular/cli": "^17.1.0",
-    "@angular/compiler": "^17.1.0",
     "@angular/compiler-cli": "^17.1.0",
     "@angular/language-service": "^17.1.0",
     "@angular/localize": "^17.1.0",


### PR DESCRIPTION
In a fresh Angular 17 app @angular/compiler is in dependencies, not devDependencies.