### PR TITLE
refactor: reduce code duplication related to markdown content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,22 +12,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 - Fix indentation in [`nginx.conf`](/nginx.conf).
 - Use `ARG` instructions in [`Dockerfile`](/Dockerfile) to define variables for setting Angular major version and Node image tag of the base image. This makes updating `Dockerfile` clearer as the Angular major version has to be changed in the file when the Angular major version of the app is updated.
-- Update Angular to 17.1.0.
-- Update htmlparser2 to 9.1.0.
-- Update marked to 11.1.1 and remove @types/marked. Move markdown parsing to function in MarkdownContentService.
-- Update zone.js to 0.14.3.
+- Refactor functions and services related to markdown content. Remove duplicate code by moving functions for getting markdown content to the markdown service. Add pipe for marking HTML safe (bypassing sanitization) in order to separate the getting and parsing of markdown to HTML from the trusting of the HTML. Rename MarkdownContentService MarkdownService.
+- Deps: update Angular to 17.1.0.
+- Deps: update htmlparser2 to 9.1.0.
+- Deps: update marked to 11.1.1 and remove @types/marked. Move markdown parsing to function in dedicated markdown service.
+- Deps: update zone.js to 0.14.3.
 - Moved @angular/compiler from devDependencies to dependencies (like in fresh Angular 17 apps).
-- Update typescript to 5.3.3.
-- Update @types/node to 20.11.5.
-- Update browser-sync to 3.0.2.
-- Update jasmine-core to 5.1.1 and @types/jasmine to 5.1.4.
+- Deps: update typescript to 5.3.3.
+- Deps: update @types/node to 20.11.5.
+- Deps: update browser-sync to 3.0.2.
+- Deps: update jasmine-core to 5.1.1 and @types/jasmine to 5.1.4.
 
 ### Removed
 
-- @angular-eslint from devDependencies.
-- jasmine-spec-reporter from devDependencies.
-- karma-coverage-istanbul-reporter from devDependencies.
-- ts-node from devDependencies.
+- Deps: @angular-eslint from devDependencies.
+- Deps: jasmine-spec-reporter from devDependencies.
+- Deps: karma-coverage-istanbul-reporter from devDependencies.
+- Deps: ts-node from devDependencies.
 
 
 

--- a/src/app/components/collection-text-types/legend/legend.component.html
+++ b/src/app/components/collection-text-types/legend/legend.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="(text$ | async) as text; else loading">
-    <div [innerHTML]="text" class="tei teiContainer legend-markdown-content markdown"></div>
+    <div [innerHTML]="text | trustHtml" class="tei teiContainer legend-markdown-content markdown"></div>
 </ng-container>
 <ng-template #loading>
     <ion-spinner class="loading" name="crescent"></ion-spinner>

--- a/src/app/components/collection-text-types/legend/legend.component.ts
+++ b/src/app/components/collection-text-types/legend/legend.component.ts
@@ -1,10 +1,10 @@
 import { Component, ElementRef, Inject, Input, LOCALE_ID, NgZone, OnDestroy, OnInit, Renderer2 } from '@angular/core';
 import { AsyncPipe, NgIf } from '@angular/common';
-import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { IonicModule } from '@ionic/angular';
 import { catchError, map, Observable, of } from 'rxjs';
 
-import { MarkdownContentService } from '@services/markdown-content.service';
+import { TrustHtmlPipe } from '@pipes/trust-html-pipe';
+import { MarkdownService } from '@services/markdown.service';
 import { ScrollService } from '@services/scroll.service';
 import { isBrowser } from '@utility-functions';
 
@@ -14,7 +14,7 @@ import { isBrowser } from '@utility-functions';
   selector: 'text-legend',
   templateUrl: './legend.component.html',
   styleUrls: ['./legend.component.scss'],
-  imports: [AsyncPipe, NgIf, IonicModule]
+  imports: [AsyncPipe, NgIf, IonicModule, TrustHtmlPipe]
 })
 export class LegendComponent implements OnDestroy, OnInit {
   @Input() itemId?: string;
@@ -24,16 +24,15 @@ export class LegendComponent implements OnDestroy, OnInit {
   intervalTimerId: number = 0;
   publicationId: string = '';
   staticMdLegendFolderNumber: string = '13';
-  text$: Observable<SafeHtml>;
+  text$: Observable<string>;
 
   private unlistenClickEvents?: () => void;
 
   constructor(
     private elementRef: ElementRef,
-    private mdContentService: MarkdownContentService,
+    private mdService: MarkdownService,
     private ngZone: NgZone,
     private renderer2: Renderer2,
-    private sanitizer: DomSanitizer,
     private scrollService: ScrollService,
     @Inject(LOCALE_ID) private activeLocale: string
   ) {}
@@ -52,15 +51,13 @@ export class LegendComponent implements OnDestroy, OnInit {
     this.unlistenClickEvents?.();
   }
 
-  getMdContent(fileID: string): Observable<SafeHtml> {
-    return this.mdContentService.getMdContent(fileID).pipe(
+  getMdContent(fileID: string): Observable<string> {
+    return this.mdService.getMdContent(fileID).pipe(
       map((res: any) => {
         if (isBrowser()) {
           this.scrollToInitialTextPosition();
         }
-        return this.sanitizer.bypassSecurityTrustHtml(
-          this.mdContentService.parseMd(res.content)
-        );
+        return this.mdService.parseMd(res.content);
       }),
       catchError(e => {
         if (fileID.split('-').length > 3) {

--- a/src/app/components/collection-text-types/legend/legend.component.ts
+++ b/src/app/components/collection-text-types/legend/legend.component.ts
@@ -59,7 +59,7 @@ export class LegendComponent implements OnDestroy, OnInit {
           this.scrollToInitialTextPosition();
         }
         return this.sanitizer.bypassSecurityTrustHtml(
-          this.mdContentService.getParsedMd(res.content)
+          this.mdContentService.parseMd(res.content)
         );
       }),
       catchError(e => {

--- a/src/app/components/content-grid/content-grid.component.ts
+++ b/src/app/components/content-grid/content-grid.component.ts
@@ -8,7 +8,7 @@ import { config } from '@config';
 import { ContentItem } from '@models/content-item.model';
 import { ParentChildPagePathPipe } from '@pipes/parent-child-page-path.pipe';
 import { CollectionsService } from '@services/collections.service';
-import { MarkdownContentService } from '@services/markdown-content.service';
+import { MarkdownService } from '@services/markdown.service';
 
 
 @Component({
@@ -28,7 +28,7 @@ export class ContentGridComponent implements OnInit {
 
   constructor(
     private collectionsService: CollectionsService,
-    private mdContentService: MarkdownContentService,
+    private mdService: MarkdownService,
     @Inject(LOCALE_ID) private activeLocale: string
   ) {
     this.availableEbooks = config.ebooks ?? [];
@@ -84,7 +84,7 @@ export class ContentGridComponent implements OnInit {
           // parallell, to fetch sequentially you'd use concatMap)
           mergeMap(
             (collection: any) => 
-              this.mdContentService.getMdContent(`${this.activeLocale}-08-${collection.id}`).pipe(
+              this.mdService.getMdContent(`${this.activeLocale}-08-${collection.id}`).pipe(
                 // add image alt-text and cover URL from response to collection data
                 map((coverRes: any) => ({
                   ...collection,

--- a/src/app/components/menus/main-side/main-side-menu.component.ts
+++ b/src/app/components/menus/main-side/main-side-menu.component.ts
@@ -8,7 +8,7 @@ import { config } from '@config';
 import { ParentChildPagePathPipe } from '@pipes/parent-child-page-path.pipe';
 import { CollectionsService } from '@services/collections.service';
 import { DocumentHeadService } from '@services/document-head.service';
-import { MarkdownContentService } from '@services/markdown-content.service';
+import { MarkdownService } from '@services/markdown.service';
 import { MediaCollectionService } from '@services/media-collection.service';
 import { addOrRemoveValueInArray, sortArrayOfObjectsAlphabetically } from '@utility-functions';
 
@@ -37,7 +37,7 @@ export class MainSideMenuComponent implements OnInit, OnChanges {
   constructor(
     private collectionsService: CollectionsService,
     private headService: DocumentHeadService,
-    private mdcontentService: MarkdownContentService,
+    private mdcontentService: MarkdownService,
     private mediaCollectionService: MediaCollectionService,
     @Inject(LOCALE_ID) private activeLocale: string
   ) {

--- a/src/app/dialogs/modals/download-texts/download-texts.modal.html
+++ b/src/app/dialogs/modals/download-texts/download-texts.modal.html
@@ -143,7 +143,7 @@
 
         <ng-template #showNotice let-instructionsText>
           <div *ngIf="copyrightText || instructionsText" class="notice">
-            <div *ngIf="instructionsText" class="markdown download-instructions" [innerHTML]="instructionsText"></div>
+            <div *ngIf="instructionsText" class="markdown download-instructions" [innerHTML]="instructionsText | trustHtml"></div>
             <p *ngIf="copyrightText && !copyrightURL" class="copyright-notice"><ng-container i18n="@@DownloadTexts.CopyrightNoticeLabel">Licens</ng-container>: <span [innerHTML]="copyrightText"></span></p>
             <p *ngIf="copyrightText && copyrightURL" class="copyright-notice">
               <ng-container i18n="@@DownloadTexts.CopyrightNoticeLabel">Licens</ng-container>: 

--- a/src/app/dialogs/modals/download-texts/download-texts.modal.ts
+++ b/src/app/dialogs/modals/download-texts/download-texts.modal.ts
@@ -1,17 +1,17 @@
 import { Component, Inject, Input, LOCALE_ID, OnDestroy, OnInit } from '@angular/core';
 import { AsyncPipe, DOCUMENT, NgClass, NgFor, NgIf, NgStyle, NgTemplateOutlet } from '@angular/common';
-import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { PRIMARY_OUTLET, Router, UrlSegment, UrlTree } from '@angular/router';
 import { IonicModule, ModalController } from '@ionic/angular';
 import { catchError, forkJoin, map, Observable, of, Subscription, tap } from 'rxjs';
 
 import { config } from '@config';
+import { TrustHtmlPipe } from '@pipes/trust-html-pipe';
 import { CollectionContentService } from '@services/collection-content.service';
 import { CollectionsService } from '@services/collections.service';
 import { CollectionTableOfContentsService } from '@services/collection-toc.service';
 import { CommentService } from '@services/comment.service';
 import { HtmlParserService } from '@services/html-parser.service';
-import { MarkdownContentService } from '@services/markdown-content.service';
+import { MarkdownService } from '@services/markdown.service';
 import { ReferenceDataService } from '@services/reference-data.service';
 import { ViewOptionsService } from '@services/view-options.service';
 import { concatenateNames } from '@utility-functions';
@@ -22,7 +22,7 @@ import { concatenateNames } from '@utility-functions';
   selector: 'modal-download-texts',
   templateUrl: './download-texts.modal.html',
   styleUrls: ['./download-texts.modal.scss'],
-  imports: [AsyncPipe, NgClass, NgFor, NgIf, NgStyle, NgTemplateOutlet, IonicModule]
+  imports: [AsyncPipe, NgClass, NgFor, NgIf, NgStyle, NgTemplateOutlet, IonicModule, TrustHtmlPipe]
 })
 export class DownloadTextsModal implements OnDestroy, OnInit {
   @Input() origin: string = '';
@@ -40,7 +40,7 @@ export class DownloadTextsModal implements OnDestroy, OnInit {
   downloadFormatsMs: string[] = [];
   downloadOptionsExist: boolean = false;
   downloadTextSubscription: Subscription | null = null;
-  instructionsText$: Observable<SafeHtml>;
+  instructionsText$: Observable<string | null>;
   introductionMode: boolean = false;
   introductionTitle: string = '';
   loadingCom: boolean = false;
@@ -68,12 +68,11 @@ export class DownloadTextsModal implements OnDestroy, OnInit {
     private collectionContentService: CollectionContentService,
     private collectionsService: CollectionsService,
     private commentService: CommentService,
-    private mdContentService: MarkdownContentService,
+    private mdService: MarkdownService,
     private modalCtrl: ModalController,
     private parserService: HtmlParserService,
     private referenceDataService: ReferenceDataService,
     private router: Router,
-    private sanitizer: DomSanitizer,
     private tocService: CollectionTableOfContentsService,
     private viewOptionsService: ViewOptionsService,
     @Inject(LOCALE_ID) private activeLocale: string,
@@ -151,7 +150,7 @@ export class DownloadTextsModal implements OnDestroy, OnInit {
 
     this.urnResolverUrl = this.referenceDataService.getUrnResolverUrl();
     this.currentUrl = this.document.defaultView?.location.href.split('?')[0] || '';
-    this.instructionsText$ = this.getMdContent(
+    this.instructionsText$ = this.mdService.getParsedMdContent(
       this.activeLocale + '-12-' + instructionsTextMdNode
     );
     this.setTranslations();
@@ -919,19 +918,6 @@ export class DownloadTextsModal implements OnDestroy, OnInit {
       'src="' + (this.document.defaultView?.location.origin ?? '')
             + (this.document.defaultView?.location.pathname.split('/')[1] === this.activeLocale ? '/' + this.activeLocale : '')
             + '/assets/images/'
-    );
-  }
-
-  private getMdContent(fileID: string): Observable<SafeHtml> {
-    return this.mdContentService.getMdContent(fileID).pipe(
-      map((res: any) => {
-        return this.sanitizer.bypassSecurityTrustHtml(
-          this.mdContentService.parseMd(res.content)
-        );
-      }),
-      catchError((e) => {
-        return of('');
-      })
     );
   }
 

--- a/src/app/dialogs/modals/download-texts/download-texts.modal.ts
+++ b/src/app/dialogs/modals/download-texts/download-texts.modal.ts
@@ -926,7 +926,7 @@ export class DownloadTextsModal implements OnDestroy, OnInit {
     return this.mdContentService.getMdContent(fileID).pipe(
       map((res: any) => {
         return this.sanitizer.bypassSecurityTrustHtml(
-          this.mdContentService.getParsedMd(res.content)
+          this.mdContentService.parseMd(res.content)
         );
       }),
       catchError((e) => {

--- a/src/app/pages/about/about.module.ts
+++ b/src/app/pages/about/about.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { IonicModule } from '@ionic/angular';
 
+import { TrustHtmlPipe } from '@pipes/trust-html-pipe';
 import { AboutPage } from './about.page';
 import { AboutPageRoutingModule } from './about-routing.module';
 
@@ -12,6 +13,7 @@ import { AboutPageRoutingModule } from './about-routing.module';
   imports: [
     CommonModule,
     IonicModule,
+    TrustHtmlPipe,
     AboutPageRoutingModule,
   ]
 })

--- a/src/app/pages/about/about.page.html
+++ b/src/app/pages/about/about.page.html
@@ -1,3 +1,3 @@
 <ion-content>
-  <article class="md_content markdown" [innerHTML]="markdownText$ | async"></article>
+  <article class="md_content markdown" [innerHTML]="(markdownText$ | async) | trustHtml"></article>
 </ion-content>

--- a/src/app/pages/about/about.page.ts
+++ b/src/app/pages/about/about.page.ts
@@ -1,7 +1,7 @@
 import { Component, Inject, LOCALE_ID, OnInit } from '@angular/core';
-import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import { SafeHtml } from '@angular/platform-browser';
 import { ActivatedRoute } from '@angular/router';
-import { catchError, map, Observable, of, switchMap } from 'rxjs';
+import { Observable, switchMap } from 'rxjs';
 
 import { MarkdownContentService } from '@services/markdown-content.service';
 
@@ -17,28 +17,16 @@ export class AboutPage implements OnInit {
   constructor(
     private mdContentService: MarkdownContentService,
     private route: ActivatedRoute,
-    private sanitizer: DomSanitizer,
     @Inject(LOCALE_ID) private activeLocale: string
   ) {}
 
   ngOnInit() {
     this.markdownText$ = this.route.params.pipe(
       switchMap(({id}) => {
-        return this.getMdContent(this.activeLocale + '-' + id);
-      })
-    );
-  }
-
-  getMdContent(fileID: string): Observable<SafeHtml> {
-    return this.mdContentService.getMdContent(fileID).pipe(
-      map((res: any) => {
-        return this.sanitizer.bypassSecurityTrustHtml(
-          this.mdContentService.getParsedMd(res.content)
+        return this.mdContentService.getParsedMdContentFromFileID(
+          this.activeLocale + '-' + id,
+          $localize`:@@About.LoadingError:Sidans innehåll kunde inte laddas.`
         );
-      }),
-      catchError((e: any) => {
-        console.error('Error loading markdown content', e);
-        return of($localize`:@@About.LoadingError:Sidans innehåll kunde inte laddas.`);
       })
     );
   }

--- a/src/app/pages/about/about.page.ts
+++ b/src/app/pages/about/about.page.ts
@@ -1,9 +1,8 @@
 import { Component, Inject, LOCALE_ID, OnInit } from '@angular/core';
-import { SafeHtml } from '@angular/platform-browser';
 import { ActivatedRoute } from '@angular/router';
 import { Observable, switchMap } from 'rxjs';
 
-import { MarkdownContentService } from '@services/markdown-content.service';
+import { MarkdownService } from '@services/markdown.service';
 
 
 @Component({
@@ -12,10 +11,10 @@ import { MarkdownContentService } from '@services/markdown-content.service';
   styleUrls: ['./about.page.scss']
 })
 export class AboutPage implements OnInit {
-  markdownText$: Observable<SafeHtml>;
+  markdownText$: Observable<string | null>;
 
   constructor(
-    private mdContentService: MarkdownContentService,
+    private mdService: MarkdownService,
     private route: ActivatedRoute,
     @Inject(LOCALE_ID) private activeLocale: string
   ) {}
@@ -23,9 +22,9 @@ export class AboutPage implements OnInit {
   ngOnInit() {
     this.markdownText$ = this.route.params.pipe(
       switchMap(({id}) => {
-        return this.mdContentService.getParsedMdContentFromFileID(
+        return this.mdService.getParsedMdContent(
           this.activeLocale + '-' + id,
-          $localize`:@@About.LoadingError:Sidans innehåll kunde inte laddas.`
+          '<p>' + $localize`:@@About.LoadingError:Sidans innehåll kunde inte laddas.` + '</p>'
         );
       })
     );

--- a/src/app/pages/collection/cover/collection-cover.page.ts
+++ b/src/app/pages/collection/cover/collection-cover.page.ts
@@ -2,7 +2,7 @@ import { Component, Inject, LOCALE_ID, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { catchError, map, Observable, of, switchMap, tap } from 'rxjs';
 
-import { MarkdownContentService } from '@services/markdown-content.service';
+import { MarkdownService } from '@services/markdown.service';
 import { PlatformService } from '@services/platform.service';
 
 
@@ -17,7 +17,7 @@ export class CollectionCoverPage implements OnInit {
   mobileMode: boolean = false;
 
   constructor(
-    private mdContentService: MarkdownContentService,
+    private mdService: MarkdownService,
     private platformService: PlatformService,
     private route: ActivatedRoute,
     @Inject(LOCALE_ID) private activeLocale: string
@@ -39,7 +39,7 @@ export class CollectionCoverPage implements OnInit {
   }
 
   private getCoverDataFromMdContent(fileID: string): Observable<any> {
-    return this.mdContentService.getMdContent(fileID).pipe(
+    return this.mdService.getMdContent(fileID).pipe(
       map((res: any) => {
         // Extract image url and alt-text from markdown content.
         let image_alt = res.content.match(/!\[(.*?)\]\(.*?\)/)[1];

--- a/src/app/pages/collection/title/collection-title.module.ts
+++ b/src/app/pages/collection/title/collection-title.module.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { IonicModule } from '@ionic/angular';
 
 import { TextChangerComponent } from '@components/text-changer/text-changer.component';
+import { TrustHtmlPipe } from '@pipes/trust-html-pipe';
 import { CollectionTitlePage } from './collection-title.page';
 import { CollectionTitlePageRoutingModule } from './collection-title-routing.module';
 
@@ -15,6 +16,7 @@ import { CollectionTitlePageRoutingModule } from './collection-title-routing.mod
     CommonModule,
     IonicModule,
     TextChangerComponent,
+    TrustHtmlPipe,
     CollectionTitlePageRoutingModule
   ],
 })

--- a/src/app/pages/collection/title/collection-title.page.html
+++ b/src/app/pages/collection/title/collection-title.page.html
@@ -30,7 +30,7 @@
           [class.teiContainer]="!loadContentFromMarkdown"
           [class.markdown]="loadContentFromMarkdown"
           [class.md_content]="loadContentFromMarkdown"
-          [innerHTML]="text"
+          [innerHTML]="text | trustHtml"
     ></div>
     <ng-template #loading>
       <ion-spinner class="loading" name="crescent"></ion-spinner>

--- a/src/app/pages/collection/title/collection-title.page.ts
+++ b/src/app/pages/collection/title/collection-title.page.ts
@@ -1,5 +1,4 @@
 import { Component, ElementRef, Inject, LOCALE_ID, OnDestroy, OnInit } from '@angular/core';
-import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { ActivatedRoute } from '@angular/router';
 import { ModalController, PopoverController } from '@ionic/angular';
 import { catchError, combineLatest, map, Observable, of, Subscription, switchMap, tap } from 'rxjs';
@@ -10,7 +9,7 @@ import { Textsize } from '@models/textsize.model';
 import { ViewOptionsPopover } from '@popovers/view-options/view-options.popover';
 import { CollectionContentService } from '@services/collection-content.service';
 import { HtmlParserService } from '@services/html-parser.service';
-import { MarkdownContentService } from '@services/markdown-content.service';
+import { MarkdownService } from '@services/markdown.service';
 import { PlatformService } from '@services/platform.service';
 import { ScrollService } from '@services/scroll.service';
 import { ViewOptionsService } from '@services/view-options.service';
@@ -30,7 +29,7 @@ export class CollectionTitlePage implements OnDestroy, OnInit {
   searchMatches: string[] = [];
   showURNButton: boolean = false;
   showViewOptionsButton: boolean = true;
-  text$: Observable<SafeHtml>;
+  text$: Observable<string | null>;
   textsize: Textsize = Textsize.Small;
   textsizeSubscription: Subscription | null = null;
 
@@ -39,12 +38,11 @@ export class CollectionTitlePage implements OnDestroy, OnInit {
   constructor(
     private collectionContentService: CollectionContentService,
     private elementRef: ElementRef,
-    private mdContentService: MarkdownContentService,
+    private mdService: MarkdownService,
     private modalController: ModalController,
     private parserService: HtmlParserService,
     private popoverCtrl: PopoverController,
     private route: ActivatedRoute,
-    private sanitizer: DomSanitizer,
     private scrollService: ScrollService,
     private platformService: PlatformService,
     private viewOptionsService: ViewOptionsService,
@@ -88,7 +86,7 @@ export class CollectionTitlePage implements OnDestroy, OnInit {
     this.textsizeSubscription?.unsubscribe();
   }
 
-  private loadTitle(id: string, lang: string): Observable<SafeHtml> {
+  private loadTitle(id: string, lang: string): Observable<string | null> {
     if (!this.loadContentFromMarkdown) {
       return this.collectionContentService.getTitle(id, lang).pipe(
         map((res: any) => {
@@ -96,40 +94,22 @@ export class CollectionTitlePage implements OnDestroy, OnInit {
             let text = this.replaceImageAssetsPaths
               ? res.content.replace(/src="images\//g, 'src="assets/images/')
               : res.content;
-            text = this.parserService.insertSearchMatchTags(text, this.searchMatches);
-            return this.sanitizer.bypassSecurityTrustHtml(text);
+            return this.parserService.insertSearchMatchTags(text, this.searchMatches);
           } else {
-            return of(this.sanitizer.bypassSecurityTrustHtml(
-              $localize`:@@CollectionTitle.None:Titelbladet kunde inte laddas.`
-            ));
+            return $localize`:@@CollectionTitle.None:Titelbladet kunde inte laddas.`;
           }
         }),
         catchError((e: any) => {
           console.error(e);
-          return of(this.sanitizer.bypassSecurityTrustHtml(
-            $localize`:@@CollectionTitle.None:Titelbladet kunde inte laddas.`
-          ));
+          return of($localize`:@@CollectionTitle.None:Titelbladet kunde inte laddas.`);
         })
       );
     } else {
-      return this.getMdContent(`${lang}-09-${id}`);
+      return this.mdService.getParsedMdContent(
+        `${lang}-09-${id}`,
+        $localize`:@@CollectionTitle.None:Titelbladet kunde inte laddas.`
+      );
     }
-  }
-
-  private getMdContent(fileID: string): Observable<SafeHtml> {
-    return this.mdContentService.getMdContent(fileID).pipe(
-      map((res: any) => {
-        return this.sanitizer.bypassSecurityTrustHtml(
-          this.mdContentService.parseMd(res.content)
-        );
-      }),
-      catchError((e: any) => {
-        console.error(e);
-        return of(this.sanitizer.bypassSecurityTrustHtml(
-          $localize`:@@CollectionTitle.None:Titelbladet kunde inte laddas.`
-        ));
-      })
-    );
   }
 
   async showViewOptionsPopover(event: any) {

--- a/src/app/pages/collection/title/collection-title.page.ts
+++ b/src/app/pages/collection/title/collection-title.page.ts
@@ -120,7 +120,7 @@ export class CollectionTitlePage implements OnDestroy, OnInit {
     return this.mdContentService.getMdContent(fileID).pipe(
       map((res: any) => {
         return this.sanitizer.bypassSecurityTrustHtml(
-          this.mdContentService.getParsedMd(res.content)
+          this.mdContentService.parseMd(res.content)
         );
       }),
       catchError((e: any) => {

--- a/src/app/pages/content/content.module.ts
+++ b/src/app/pages/content/content.module.ts
@@ -4,6 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { IonicModule } from '@ionic/angular';
 
 import { ContentGridComponent } from '@components/content-grid/content-grid.component';
+import { TrustHtmlPipe } from '@pipes/trust-html-pipe';
 import { ContentPage } from './content.page';
 import { ContentPageRoutingModule } from './content-routing.module';
 
@@ -17,6 +18,7 @@ import { ContentPageRoutingModule } from './content-routing.module';
     FormsModule,
     IonicModule,
     ContentGridComponent,
+    TrustHtmlPipe,
     ContentPageRoutingModule
   ]
 })

--- a/src/app/pages/content/content.page.html
+++ b/src/app/pages/content/content.page.html
@@ -3,7 +3,7 @@
   <h1 class="page-title" i18n="@@TopMenu.Content">Innehåll</h1>
 
   <ng-container *ngIf="(mdContent$ | async) as mdContent">
-    <div class="info markdown" [innerHTML]="mdContent"></div>
+    <div class="info markdown" [innerHTML]="mdContent | trustHtml"></div>
   </ng-container>
 
   <content-grid></content-grid>

--- a/src/app/pages/content/content.page.ts
+++ b/src/app/pages/content/content.page.ts
@@ -1,8 +1,7 @@
-import { Component, Inject, LOCALE_ID, OnInit, SecurityContext } from '@angular/core';
-import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
-import { catchError, map, Observable, of } from 'rxjs';
+import { Component, Inject, LOCALE_ID, OnInit } from '@angular/core';
+import { Observable } from 'rxjs';
 
-import { MarkdownContentService } from '@services/markdown-content.service';
+import { MarkdownService } from '@services/markdown.service';
 
 
 @Component({
@@ -11,32 +10,16 @@ import { MarkdownContentService } from '@services/markdown-content.service';
   styleUrls: ['./content.page.scss']
 })
 export class ContentPage implements OnInit {
-  mdContent$: Observable<SafeHtml | null>;
+  mdContent$: Observable<string | null>;
 
   constructor(
-    private mdContentService: MarkdownContentService,
-    private sanitizer: DomSanitizer,
+    private mdService: MarkdownService,
     @Inject(LOCALE_ID) private activeLocale: string
   ) {}
 
   ngOnInit() {
-    this.mdContent$ = this.getMdContent(this.activeLocale + '-02').pipe(
-      map((res: string) => {
-        return this.sanitizer.sanitize(
-          SecurityContext.HTML, this.sanitizer.bypassSecurityTrustHtml(res)
-        );
-      })
-    );
-  }
-
-  getMdContent(fileID: string): Observable<string> {
-    return this.mdContentService.getMdContent(fileID).pipe(
-      map((res: any) => {
-        return this.mdContentService.parseMd(res.content);
-      }),
-      catchError(e => {
-        return of('');
-      })
+    this.mdContent$ = this.mdService.getParsedMdContent(
+      this.activeLocale + '-02'
     );
   }
 

--- a/src/app/pages/content/content.page.ts
+++ b/src/app/pages/content/content.page.ts
@@ -32,7 +32,7 @@ export class ContentPage implements OnInit {
   getMdContent(fileID: string): Observable<string> {
     return this.mdContentService.getMdContent(fileID).pipe(
       map((res: any) => {
-        return this.mdContentService.getParsedMd(res.content);
+        return this.mdContentService.parseMd(res.content);
       }),
       catchError(e => {
         return of('');

--- a/src/app/pages/elastic-search/elastic-search.module.ts
+++ b/src/app/pages/elastic-search/elastic-search.module.ts
@@ -6,6 +6,7 @@ import { IonicModule } from '@ionic/angular';
 import { DateHistogramComponent } from '@components/date-histogram/date-histogram.component';
 import { ElasticHitCollectionPagePathPipe } from '@pipes/elastic-hit-collection-page-path.pipe';
 import { ElasticHitCollectionPageQueryparamsPipe } from '@pipes/elastic-hit-collection-page-queryparams.pipe';
+import { TrustHtmlPipe } from '@pipes/trust-html-pipe';
 import { ElasticSearchPageRoutingModule } from './elastic-search-routing.module';
 import { ElasticSearchPage } from './elastic-search.page';
 
@@ -21,6 +22,7 @@ import { ElasticSearchPage } from './elastic-search.page';
     DateHistogramComponent,
     ElasticHitCollectionPagePathPipe,
     ElasticHitCollectionPageQueryparamsPipe,
+    TrustHtmlPipe,
     ElasticSearchPageRoutingModule
   ]
 })

--- a/src/app/pages/elastic-search/elastic-search.page.html
+++ b/src/app/pages/elastic-search/elastic-search.page.html
@@ -3,7 +3,7 @@
   <h1 class="page-title" i18n="@@ElasticSearch.SearchEdition">Sök i utgåvan</h1>
 
   <ng-container *ngIf="(mdContent$ | async) as mdContent">
-    <div class="info markdown" [innerHTML]="mdContent"></div>
+    <div class="info markdown" [innerHTML]="mdContent | trustHtml"></div>
   </ng-container>
 
   <div class="search-container">

--- a/src/app/pages/elastic-search/elastic-search.page.ts
+++ b/src/app/pages/elastic-search/elastic-search.page.ts
@@ -1,13 +1,12 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, Inject, LOCALE_ID, OnDestroy, OnInit, ViewChild } from '@angular/core';
-import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { ActivatedRoute, Router } from '@angular/router';
 import { IonContent } from '@ionic/angular';
-import { catchError, map, merge, Observable, of, Subject, Subscription, switchMap } from 'rxjs';
+import { map, merge, Observable, of, Subject, Subscription, switchMap } from 'rxjs';
 
 import { config } from '@config';
 import { AggregationData, AggregationsData, Facet, Facets, TimeRange } from '@models/elastic-search.model';
 import { ElasticSearchService } from '@services/elastic-search.service';
-import { MarkdownContentService } from '@services/markdown-content.service';
+import { MarkdownService } from '@services/markdown.service';
 import { PlatformService } from '@services/platform.service';
 import { UrlService } from '@services/url.service';
 import { isBrowser, isEmptyObject, sortArrayOfObjectsNumerically } from '@utility-functions';
@@ -37,7 +36,7 @@ export class ElasticSearchPage implements OnDestroy, OnInit {
   initializing: boolean = true;
   loading: boolean = true;
   loadingMoreHits: boolean = false;
-  mdContent$: Observable<SafeHtml>;
+  mdContent$: Observable<string | null>;
   pages: number = 1;
   query: string = ''; // variable bound to the input search field with ngModel
   range?: TimeRange | null = undefined;
@@ -59,11 +58,10 @@ export class ElasticSearchPage implements OnDestroy, OnInit {
     private cf: ChangeDetectorRef,
     private elasticService: ElasticSearchService,
     private elementRef: ElementRef,
-    private mdContentService: MarkdownContentService,
+    private mdService: MarkdownService,
     private platformService: PlatformService,
     private route: ActivatedRoute,
     private router: Router,
-    private sanitizer: DomSanitizer,
     private urlService: UrlService,
     @Inject(LOCALE_ID) private activeLocale: string
   ) {
@@ -98,7 +96,9 @@ export class ElasticSearchPage implements OnDestroy, OnInit {
   }
 
   ngOnInit() {
-    this.mdContent$ = this.getMdContent(this.activeLocale + '-12-01');
+    this.mdContent$ = this.mdService.getParsedMdContent(
+      this.activeLocale + '-12-01'
+    );
 
     // Set up search data stream subscriptions
     this.subscribeToSearchDataStreams();
@@ -454,19 +454,6 @@ export class ElasticSearchPage implements OnDestroy, OnInit {
     this.from += this.hitsPerPage;
 
     this.updateURLQueryParameters({ pages: this.pages + 1 });
-  }
-
-  private getMdContent(fileID: string): Observable<SafeHtml> {
-    return this.mdContentService.getMdContent(fileID).pipe(
-      map((res: any) => {
-        return this.sanitizer.bypassSecurityTrustHtml(
-          this.mdContentService.parseMd(res.content)
-        );
-      }),
-      catchError((e) => {
-        return of('');
-      })
-    );
   }
 
   private getInitialAggregations(): Observable<any> {

--- a/src/app/pages/elastic-search/elastic-search.page.ts
+++ b/src/app/pages/elastic-search/elastic-search.page.ts
@@ -460,7 +460,7 @@ export class ElasticSearchPage implements OnDestroy, OnInit {
     return this.mdContentService.getMdContent(fileID).pipe(
       map((res: any) => {
         return this.sanitizer.bypassSecurityTrustHtml(
-          this.mdContentService.getParsedMd(res.content)
+          this.mdContentService.parseMd(res.content)
         );
       }),
       catchError((e) => {

--- a/src/app/pages/home/home.module.ts
+++ b/src/app/pages/home/home.module.ts
@@ -4,6 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { IonicModule } from '@ionic/angular';
 
 import { ContentGridComponent } from '@components/content-grid/content-grid.component';
+import { TrustHtmlPipe } from '@pipes/trust-html-pipe';
 import { HomePageRoutingModule } from './home-routing.module';
 import { HomePage } from './home.page';
 
@@ -17,6 +18,7 @@ import { HomePage } from './home.page';
     FormsModule,
     IonicModule,
     ContentGridComponent,
+    TrustHtmlPipe,
     HomePageRoutingModule
   ],
 })

--- a/src/app/pages/home/home.page.html
+++ b/src/app/pages/home/home.page.html
@@ -49,12 +49,12 @@
       </ion-button>
     </div>
 
-    <div class="site-presentation markdown" [innerHTML]="descriptionText$ | async"></div>
+    <div class="site-presentation markdown" [innerHTML]="(descriptionText$ | async) | trustHtml"></div>
 
     <div *ngIf="showContentGrid" class="content-grid-wrapper">
       <content-grid></content-grid>
     </div>
 
-    <footer *ngIf="showFooter" class="footer markdown" [innerHTML]="footerText$ | async"></footer>
+    <footer *ngIf="showFooter" class="footer markdown" [innerHTML]="(footerText$ | async) | trustHtml"></footer>
   </div>
 </ion-content>

--- a/src/app/pages/home/home.page.ts
+++ b/src/app/pages/home/home.page.ts
@@ -1,10 +1,9 @@
 import { Component, Inject, LOCALE_ID, OnInit } from '@angular/core';
-import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { Router } from '@angular/router';
-import { catchError, map, Observable, of } from 'rxjs';
+import { Observable } from 'rxjs';
 
 import { config } from '@config';
-import { MarkdownContentService } from '@services/markdown-content.service';
+import { MarkdownService } from '@services/markdown.service';
 
 
 @Component({
@@ -13,8 +12,8 @@ import { MarkdownContentService } from '@services/markdown-content.service';
   styleUrls: ['./home.page.scss'],
 })
 export class HomePage implements OnInit {
-  descriptionText$: Observable<SafeHtml>;
-  footerText$: Observable<SafeHtml>;
+  descriptionText$: Observable<string | null>;
+  footerText$: Observable<string | null>;
   imageAltText: string = '';
   imageOnRight: boolean = false;
   imageOrientationPortrait: boolean = false;
@@ -29,9 +28,8 @@ export class HomePage implements OnInit {
   titleOnImage: boolean = false;
 
   constructor(
-    private mdContentService: MarkdownContentService,
+    private mdService: MarkdownService,
     private router: Router,
-    private sanitizer: DomSanitizer,
     @Inject(LOCALE_ID) private activeLocale: string
   ) {
     this.imageAltText = config.page?.home?.bannerImage?.altTexts?.[this.activeLocale] ?? 'image';
@@ -57,33 +55,21 @@ export class HomePage implements OnInit {
   }
 
   ngOnInit() {
-    this.descriptionText$ = this.getMdContent(this.activeLocale + '-01');
-    if (this.showFooter) {
-      this.footerText$ = this.getMdContent(this.activeLocale + '-06');
-    }
-  }
-
-  private getMdContent(fileID: string): Observable<SafeHtml> {
-    return this.mdContentService.getMdContent(fileID).pipe(
-      map((res: any) => {
-        return this.sanitizer.bypassSecurityTrustHtml(
-          this.mdContentService.parseMd(res.content)
-        );
-      }),
-      catchError((e) => {
-        console.error(e);
-        return of('');
-      })
+    this.descriptionText$ = this.mdService.getParsedMdContent(
+      this.activeLocale + '-01'
     );
+    if (this.showFooter) {
+      this.footerText$ = this.mdService.getParsedMdContent(
+        this.activeLocale + '-06'
+      );
+    }
   }
 
   submitSearchQuery() {
     if (this.searchQuery) {
       this.router.navigate(
         ['/search'],
-        {
-          queryParams: { query: this.searchQuery }
-        }
+        { queryParams: { query: this.searchQuery } }
       );
     }
   }

--- a/src/app/pages/home/home.page.ts
+++ b/src/app/pages/home/home.page.ts
@@ -67,7 +67,7 @@ export class HomePage implements OnInit {
     return this.mdContentService.getMdContent(fileID).pipe(
       map((res: any) => {
         return this.sanitizer.bypassSecurityTrustHtml(
-          this.mdContentService.getParsedMd(res.content)
+          this.mdContentService.parseMd(res.content)
         );
       }),
       catchError((e) => {

--- a/src/app/pages/index/index.module.ts
+++ b/src/app/pages/index/index.module.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { IonicModule } from '@ionic/angular';
 
+import { TrustHtmlPipe } from '@pipes/trust-html-pipe';
 import { IndexPageRoutingModule } from './index-routing.module';
 import { IndexPage } from './index.page';
 
@@ -15,6 +16,7 @@ import { IndexPage } from './index.page';
     CommonModule,
     FormsModule,
     IonicModule,
+    TrustHtmlPipe,
     IndexPageRoutingModule
   ]
 })

--- a/src/app/pages/index/index.page.html
+++ b/src/app/pages/index/index.page.html
@@ -16,7 +16,7 @@
   </h1>
 
   <ng-container *ngIf="(mdContent$ | async) as mdContent">
-    <div class="info markdown" [innerHTML]="mdContent"></div>
+    <div class="info markdown" [innerHTML]="mdContent | trustHtml"></div>
   </ng-container>
 
   <div class="index-container">

--- a/src/app/pages/index/index.page.ts
+++ b/src/app/pages/index/index.page.ts
@@ -1,13 +1,12 @@
 import { Component, Inject, LOCALE_ID, OnInit, ViewChild } from '@angular/core';
-import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { ActivatedRoute, Router } from '@angular/router';
 import { IonContent, ModalController } from '@ionic/angular';
-import { catchError, map, Observable, of, Subscription } from 'rxjs';
+import { Observable, Subscription } from 'rxjs';
 
 import { config } from '@config';
 import { IndexFilterModal } from '@modals/index-filter/index-filter.modal';
 import { NamedEntityModal } from '@modals/named-entity/named-entity.modal';
-import { MarkdownContentService } from '@services/markdown-content.service';
+import { MarkdownService } from '@services/markdown.service';
 import { NamedEntityService } from '@services/named-entity.service';
 import { TooltipService } from '@services/tooltip.service';
 import { sortArrayOfObjectsAlphabetically } from '@utility-functions';
@@ -38,7 +37,7 @@ export class IndexPage implements OnInit {
   itemType: string = '';
   lastFetchSize: number = 0;
   maxFetchSize: number = 500;
-  mdContent$: Observable<SafeHtml>;
+  mdContent$: Observable<string | null>;
   routeParamsSubscription: Subscription | null = null;
   routeQueryParamsSubscription: Subscription | null = null;
   searchText: string = '';
@@ -46,12 +45,11 @@ export class IndexPage implements OnInit {
   showLoading: boolean = true;
 
   constructor(
-    private mdContentService: MarkdownContentService,
+    private mdService: MarkdownService,
     private modalCtrl: ModalController,
     private namedEntityService: NamedEntityService,
     public route: ActivatedRoute,
     private router: Router,
-    private sanitizer: DomSanitizer,
     private tooltipService: TooltipService,
     @Inject(LOCALE_ID) private activeLocale: string
   ) {}
@@ -97,7 +95,7 @@ export class IndexPage implements OnInit {
       }
 
       if (indexTypeMdNodeID) {
-        this.mdContent$ = this.getMdContent(
+        this.mdContent$ = this.mdService.getParsedMdContent(
           this.activeLocale + '-' + indexTypeMdNodeID
         );
       }
@@ -117,19 +115,6 @@ export class IndexPage implements OnInit {
   ngOnDestroy() {
     this.routeParamsSubscription?.unsubscribe();
     this.routeQueryParamsSubscription?.unsubscribe();
-  }
-
-  private getMdContent(fileID: string): Observable<SafeHtml> {
-    return this.mdContentService.getMdContent(fileID).pipe(
-      map((res: any) => {
-        return this.sanitizer.bypassSecurityTrustHtml(
-          this.mdContentService.parseMd(res.content)
-        );
-      }),
-      catchError((e) => {
-        return of('');
-      })
-    );
   }
 
   private getIndexData() {

--- a/src/app/pages/index/index.page.ts
+++ b/src/app/pages/index/index.page.ts
@@ -123,7 +123,7 @@ export class IndexPage implements OnInit {
     return this.mdContentService.getMdContent(fileID).pipe(
       map((res: any) => {
         return this.sanitizer.bypassSecurityTrustHtml(
-          this.mdContentService.getParsedMd(res.content)
+          this.mdContentService.parseMd(res.content)
         );
       }),
       catchError((e) => {

--- a/src/app/pages/media-collection/media-collection.module.ts
+++ b/src/app/pages/media-collection/media-collection.module.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { IonicModule } from '@ionic/angular';
 
+import { TrustHtmlPipe } from '@pipes/trust-html-pipe';
 import { MediaCollectionPageRoutingModule } from './media-collection-routing.module';
 import { MediaCollectionPage } from './media-collection.page';
 
@@ -15,6 +16,7 @@ import { MediaCollectionPage } from './media-collection.page';
     CommonModule,
     FormsModule,
     IonicModule,
+    TrustHtmlPipe,
     MediaCollectionPageRoutingModule
   ],
 })

--- a/src/app/pages/media-collection/media-collection.page.html
+++ b/src/app/pages/media-collection/media-collection.page.html
@@ -29,7 +29,7 @@
   <p *ngIf="mediaCollectionDescription" [innerHTML]="mediaCollectionDescription"></p>
 
   <ng-container *ngIf="(mdContent$ | async) as mdContent">
-    <div class="info markdown" [innerHTML]="mdContent"></div>
+    <div class="info markdown" [innerHTML]="mdContent | trustHtml"></div>
   </ng-container>
 
   <ng-container *ngIf="loadingGallery">

--- a/src/app/pages/media-collection/media-collection.page.ts
+++ b/src/app/pages/media-collection/media-collection.page.ts
@@ -188,7 +188,7 @@ export class MediaCollectionPage implements OnDestroy, OnInit {
       map((res: any) => {
         return this.sanitizer.sanitize(
           SecurityContext.HTML, this.sanitizer.bypassSecurityTrustHtml(
-            this.mdContentService.getParsedMd(res.content)
+            this.mdContentService.parseMd(res.content)
           )
         );
       }),

--- a/src/app/pages/media-collection/media-collection.page.ts
+++ b/src/app/pages/media-collection/media-collection.page.ts
@@ -1,15 +1,14 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Inject, LOCALE_ID, OnDestroy, OnInit, SecurityContext } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Inject, LOCALE_ID, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { ModalController } from '@ionic/angular';
-import { catchError, combineLatest, forkJoin, map, Observable, of, Subscription } from 'rxjs';
+import { combineLatest, forkJoin, map, Observable, Subscription } from 'rxjs';
 
 import { config } from '@config';
 import { ReferenceDataModal } from '@modals/reference-data/reference-data.modal';
 import { GalleryItem } from '@models/gallery-item-model';
 import { FullscreenImageViewerModal } from '@modals/fullscreen-image-viewer/fullscreen-image-viewer.modal';
 import { DocumentHeadService } from '@services/document-head.service';
-import { MarkdownContentService } from '@services/markdown-content.service';
+import { MarkdownService } from '@services/markdown.service';
 import { MediaCollectionService } from '@services/media-collection.service';
 import { UrlService } from '@services/url.service';
 import { isEmptyObject, sortArrayOfObjectsAlphabetically, sortArrayOfObjectsNumerically } from '@utility-functions';
@@ -41,7 +40,7 @@ export class MediaCollectionPage implements OnDestroy, OnInit {
   galleryTitles: (string | undefined)[] = [];
   loadingGallery: boolean = true;
   loadingImageModal: boolean = false;
-  mdContent$: Observable<SafeHtml | null>;
+  mdContent$: Observable<string | null>;
   mediaCollectionID: string | undefined = undefined;
   mediaCollectionDescription: string = '';
   mediaCollectionTitle: string = '';
@@ -54,12 +53,11 @@ export class MediaCollectionPage implements OnDestroy, OnInit {
   constructor(
     private cdRef: ChangeDetectorRef,
     private headService: DocumentHeadService,
-    private mdContentService: MarkdownContentService,
+    private mdService: MarkdownService,
     private mediaCollectionService: MediaCollectionService,
     private modalController: ModalController,
     private route: ActivatedRoute,
     private router: Router,
-    private sanitizer: DomSanitizer,
     private urlService: UrlService,
     @Inject(LOCALE_ID) private activeLocale: string
   ) {
@@ -111,7 +109,9 @@ export class MediaCollectionPage implements OnDestroy, OnInit {
         this.namedEntityID = '';
         this.mediaCollectionTitle = $localize`:@@MainSideMenu.MediaCollections:Bildbank`;
         this.cdRef.detectChanges();
-        this.mdContent$ = this.getMdContent(this.activeLocale + '-11-all');
+        this.mdContent$ = this.mdService.getParsedMdContent(
+          this.activeLocale + '-11-all'
+        );
 
         if (routeParams.filters) {
           this.setActiveFiltersFromQueryParams(routeParams.filters);
@@ -183,21 +183,6 @@ export class MediaCollectionPage implements OnDestroy, OnInit {
     this.urlParametersSubscription?.unsubscribe();
   }
 
-  private getMdContent(fileID: string): Observable<SafeHtml | null> {
-    return this.mdContentService.getMdContent(fileID).pipe(
-      map((res: any) => {
-        return this.sanitizer.sanitize(
-          SecurityContext.HTML, this.sanitizer.bypassSecurityTrustHtml(
-            this.mdContentService.parseMd(res.content)
-          )
-        );
-      }),
-      catchError((e) => {
-        return of('');
-      })
-    );
-  }
-
   private loadMediaCollections() {
     this.galleryData = [];
 
@@ -239,7 +224,9 @@ export class MediaCollectionPage implements OnDestroy, OnInit {
       }
     }
 
-    this.mdContent$ = this.getMdContent(this.activeLocale + '-11-' + mediaCollectionID);
+    this.mdContent$ = this.mdService.getParsedMdContent(
+      this.activeLocale + '-11-' + mediaCollectionID
+    );
 
     // Get selected media collection data, then filter options and apply any active filters
     this.mediaCollectionService.getSingleMediaCollection(mediaCollectionID, this.activeLocale).subscribe(

--- a/src/app/pages/page-not-found/page-not-found.module.ts
+++ b/src/app/pages/page-not-found/page-not-found.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { IonicModule } from '@ionic/angular';
 
+import { TrustHtmlPipe } from '@pipes/trust-html-pipe';
 import { PageNotFoundPageRoutingModule } from './page-not-found-routing.module';
 import { PageNotFoundPage } from './page-not-found.page';
 
@@ -13,6 +14,7 @@ import { PageNotFoundPage } from './page-not-found.page';
   imports: [
     CommonModule,
     IonicModule,
+    TrustHtmlPipe,
     PageNotFoundPageRoutingModule
   ]
 })

--- a/src/app/pages/page-not-found/page-not-found.page.html
+++ b/src/app/pages/page-not-found/page-not-found.page.html
@@ -4,6 +4,6 @@
       <ion-icon name="warning-outline"></ion-icon>
       <ng-container i18n="@@PageNotFound.404PageNotFound">404 Sidan hittas inte</ng-container>
     </h1>
-    <div class="markdown" [innerHTML]="(markdownText$ | async)"></div>
+    <div class="markdown" [innerHTML]="(markdownText$ | async) | trustHtml"></div>
   </article>
 </ion-content>

--- a/src/app/pages/page-not-found/page-not-found.page.ts
+++ b/src/app/pages/page-not-found/page-not-found.page.ts
@@ -1,8 +1,7 @@
 import { Component, Inject, LOCALE_ID, OnInit } from '@angular/core';
-import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
-import { catchError, map, Observable, of } from 'rxjs';
+import { Observable } from 'rxjs';
 
-import { MarkdownContentService } from '@services/markdown-content.service';
+import { MarkdownService } from '@services/markdown.service';
 
 
 @Component({
@@ -11,35 +10,19 @@ import { MarkdownContentService } from '@services/markdown-content.service';
   styleUrls: ['./page-not-found.page.scss'],
 })
 export class PageNotFoundPage implements OnInit {
-  markdownText$: Observable<SafeHtml>;
+  markdownText$: Observable<string | null>;
 
   constructor(
-    private mdContentService: MarkdownContentService,
-    private sanitizer: DomSanitizer,
+    private mdService: MarkdownService,
     @Inject(LOCALE_ID) private activeLocale: string
   ) {}
 
   ngOnInit() {
-    this.markdownText$ = this.getMdContent(this.activeLocale + '-404');
-  }
-
-  private getMdContent(fileID: string): Observable<SafeHtml> {
-    return this.mdContentService.getMdContent(fileID).pipe(
-      map((res: any) => {
-        return this.sanitizer.bypassSecurityTrustHtml(
-          this.mdContentService.parseMd(res.content)
-        );
-      }),
-      catchError((e: any) => {
-        console.error('Error getting markdown page content from backend', e);
-        return of(
-          this.sanitizer.bypassSecurityTrustHtml(
-            '<p>' +
-            $localize`:@@PageNotFound.DefaultMessage:Något gick fel. Vi kan inte hitta sidan du försökte nå. Du kan gå tillbaka till föregående sida med hjälp av webbläsarens tillbaka-knapp, eller försöka rätta adressen i webbläsarens adressfält.`
-            + '</p>'
-          )
-        );
-      })
+    this.markdownText$ = this.mdService.getParsedMdContent(
+      this.activeLocale + '-404',
+      '<p>'
+      + $localize`:@@PageNotFound.DefaultMessage:Något gick fel. Vi kan inte hitta sidan du försökte nå. Du kan gå tillbaka till föregående sida med hjälp av webbläsarens tillbaka-knapp, eller försöka rätta adressen i webbläsarens adressfält.`
+      + '</p>'
     );
   }
 

--- a/src/app/pages/page-not-found/page-not-found.page.ts
+++ b/src/app/pages/page-not-found/page-not-found.page.ts
@@ -27,7 +27,7 @@ export class PageNotFoundPage implements OnInit {
     return this.mdContentService.getMdContent(fileID).pipe(
       map((res: any) => {
         return this.sanitizer.bypassSecurityTrustHtml(
-          this.mdContentService.getParsedMd(res.content)
+          this.mdContentService.parseMd(res.content)
         );
       }),
       catchError((e: any) => {

--- a/src/app/pipes/trust-html-pipe.ts
+++ b/src/app/pipes/trust-html-pipe.ts
@@ -1,0 +1,18 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+
+
+/**
+ * Bypass security and trust the given value to be safe HTML.
+ */
+@Pipe({
+  name: 'trustHtml',
+  standalone: true
+})
+export class TrustHtmlPipe implements PipeTransform {
+  constructor(private sanitizer: DomSanitizer) {}
+
+  transform(html: string | null): SafeHtml {
+    return this.sanitizer.bypassSecurityTrustHtml(html ?? '');
+  }
+}


### PR DESCRIPTION
Refactor functions and services related to markdown content. Remove duplicate code by moving functions for getting markdown content to the markdown service. Add pipe for marking HTML safe (bypassing sanitization) in order to separate the getting and parsing of markdown to HTML from the trusting of the HTML. Rename MarkdownContentService MarkdownService.