### PR TITLE
perf: defer loading facsimiles to browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Changed
 
+- Defer loading of the facsimile component on the collection text page to the browser. This increases server-side rendering performance since the component isn’t rendered on the server.
 - Deps: update Angular to 17.1.2.
 - Deps: update Ionic to 7.7.0.
 - Deps: update `marked` to 11.2.0.

--- a/src/app/pages/collection/text/collection-text.page.html
+++ b/src/app/pages/collection/text/collection-text.page.html
@@ -300,14 +300,20 @@
         (setMobileModeActiveText)="setActiveMobileModeViewType(undefined, $event)"
   ></comments>
 
-  <facsimiles *ngIf="view.type === 'facsimiles'"
-        [textItemID]="textItemID"
-        [facsID]="view.id"
-        [imageNr]="view.nr"
-        (selectedFacsID)="updateViewProperty('id', $event, i)"
-        (selectedImageNr)="updateViewProperty('nr', $event, i)"
-        (selectedFacsName)="updateViewProperty('title', $event, i, false)"
-  ></facsimiles>
+  <ng-container *ngIf="view.type === 'facsimiles'">
+    @defer {
+      <facsimiles
+            [textItemID]="textItemID"
+            [facsID]="view.id"
+            [imageNr]="view.nr"
+            (selectedFacsID)="updateViewProperty('id', $event, i)"
+            (selectedImageNr)="updateViewProperty('nr', $event, i)"
+            (selectedFacsName)="updateViewProperty('title', $event, i, false)"
+      ></facsimiles>
+    } @loading (minimum 1s) {
+      <ion-spinner class="loading" name="crescent"></ion-spinner>
+    }
+  </ng-container>
 
   <manuscripts *ngIf="view.type === 'manuscripts'"
         [textItemID]="textItemID"


### PR DESCRIPTION
Defer loading of the facsimile component on the collection text page to the browser. This increases server-side rendering performance since the component isn’t rendered on the server.