### PR TITLE
perf: defer loading illustrations component to browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Changed
 
 - Defer loading of the facsimile component on the collection text page to the browser. This increases server-side rendering performance since the component isn’t rendered on the server.
+- Defer loading of the illustrations component on the collection text page to the browser. This increases server-side rendering performance since the component isn’t rendered on the server.
 - Deps: update Angular to 17.1.2.
 - Deps: update Ionic to 7.7.0.
 - Deps: update `marked` to 11.2.0.

--- a/src/app/pages/collection/text/collection-text.page.html
+++ b/src/app/pages/collection/text/collection-text.page.html
@@ -337,12 +337,18 @@
         (openNewLegendView)="openNewView($event)"
   ></variants>
   
-  <illustrations *ngIf="view.type === 'illustrations'"
-        [singleImage]="view.image"
-        [textItemID]="textItemID"
-        (showAllImages)="updateIllustrationViewImage($event)"
-        (setMobileModeActiveText)="setActiveMobileModeViewType(undefined, $event)"
-  ></illustrations>
+  <ng-container *ngIf="view.type === 'illustrations'">
+    @defer {
+      <illustrations
+            [singleImage]="view.image"
+            [textItemID]="textItemID"
+            (showAllImages)="updateIllustrationViewImage($event)"
+            (setMobileModeActiveText)="setActiveMobileModeViewType(undefined, $event)"
+      ></illustrations>
+    } @loading (minimum 1s) {
+      <ion-spinner class="loading" name="crescent"></ion-spinner>
+    }
+  </ng-container>
 
   <text-legend *ngIf="view.type === 'legend'"
         [itemId]="textItemID"


### PR DESCRIPTION
Defer loading of the illustrations component on the collection text page to the browser. This increases server-side rendering performance since the component isn’t rendered on the server.