### PR TITLE
fix: document title not set by SSR

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -2,9 +2,17 @@
 
   <header>
     <nav class="top-navigation" aria-labelledby="top-menu-label">
-      <top-menu (sideNavClick)="toggleSideNav()" [showSideNav]="showSideNav" [currentRouterUrl]="currentRouterUrl"></top-menu>
+      <top-menu
+            (sideNavClick)="toggleSideNav()"
+            [showSideNav]="showSideNav"
+            [currentRouterUrl]="currentRouterUrl"
+      ></top-menu>
     </nav>
-    <ion-progress-bar *ngIf="enableRouterLoadingBar" [class.showLoadingBar]="!loadingBarHidden" type="indeterminate" mode="ios"></ion-progress-bar>
+    <ion-progress-bar *ngIf="enableRouterLoadingBar"
+          [class.showLoadingBar]="!loadingBarHidden"
+          type="indeterminate"
+          mode="ios"
+    ></ion-progress-bar>
   </header>
   <div class="content-container">
     <nav id="side-navigation"
@@ -30,8 +38,8 @@
         @defer {
           <collection-side-menu
                 [collectionID]="collectionID"
-                [initialQueryParams]="collectionSideMenuInitialQueryParams"
-                [initialUrlSegments]="collectionSideMenuInitialUrlSegments"
+                [routeQueryParams]="collSideMenuQueryParams"
+                [routeUrlSegments]="collSideMenuUrlSegments"
                 [sideMenuToggled]="showSideNav"
           ></collection-side-menu>
         } @placeholder {
@@ -43,14 +51,18 @@
       <ng-container *ngIf="showCollectionSideMenu && enableCollectionSideMenuSSR">
         <collection-side-menu
               [collectionID]="collectionID"
-              [initialQueryParams]="collectionSideMenuInitialQueryParams"
-              [initialUrlSegments]="collectionSideMenuInitialUrlSegments"
+              [routeQueryParams]="collSideMenuQueryParams"
+              [routeUrlSegments]="collSideMenuUrlSegments"
               [sideMenuToggled]="showSideNav"
         ></collection-side-menu>
       </ng-container>
     </nav>
     <div class="main-content">
-      <ion-router-outlet [animated]="false" (activate)="hideLoadingBar(true)" (deactivate)="hideLoadingBar(false)"></ion-router-outlet>
+      <ion-router-outlet
+            [animated]="false"
+            (activate)="hideLoadingBar(true)"
+            (deactivate)="hideLoadingBar(false)"
+      ></ion-router-outlet>
       <div *ngIf="mobileMode && showSideNav" class="backdrop-dismiss" (click)="toggleSideNav()"></div>
     </div>
   </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -81,6 +81,10 @@ export class AppComponent implements OnDestroy, OnInit {
         // displayed.
         this.mountMainSideMenu = true;
         this.showCollectionSideMenu = false;
+        // Clear the collection TOC loaded in the collection side menu
+        // to prevent the previous TOC from flashing in view when
+        // entering another collection.
+        this.tocService.setCurrentCollectionToc('');
       }
 
       // Hide side menu if:

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,6 +3,7 @@ import { NavigationEnd, Params, PRIMARY_OUTLET, Router, UrlSegment, UrlTree } fr
 import { filter, Subscription } from 'rxjs';
 
 import { config } from '@config';
+import { CollectionTableOfContentsService } from '@services/collection-toc.service';
 import { DocumentHeadService } from '@services/document-head.service';
 import { PlatformService } from '@services/platform.service';
 import { isBrowser } from '@utility-functions';
@@ -33,7 +34,8 @@ export class AppComponent implements OnDestroy, OnInit {
   constructor(
     private headService: DocumentHeadService,
     private platformService: PlatformService,
-    private router: Router
+    private router: Router,
+    private tocService: CollectionTableOfContentsService
   ) {
     this.enableCollectionSideMenuSSR = config.app?.ssr?.collectionSideMenu ?? false;
     this.enableRouterLoadingBar = config.app?.enableRouterLoadingBar ?? false;
@@ -60,7 +62,13 @@ export class AppComponent implements OnDestroy, OnInit {
       // Check if a collection page in order to show collection side
       // menu instead of main side menu.
       if (this.currentUrlSegments?.[0]?.path === 'collection') {
-        this.collectionID = this.currentUrlSegments[1]?.path || '';
+        const newCollectionID = this.currentUrlSegments[1]?.path || '';
+        
+        if (this.collectionID !== newCollectionID) {
+          this.collectionID = newCollectionID;
+          this.tocService.setCurrentCollectionTOC(this.collectionID);
+        }
+
         this.collectionSideMenuInitialUrlSegments = this.currentUrlSegments;
         this.collectionSideMenuInitialQueryParams = currentUrlTree?.queryParams;
         this.showCollectionSideMenu = true;

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -17,8 +17,8 @@ import { isBrowser } from '@utility-functions';
 export class AppComponent implements OnDestroy, OnInit {
   appIsStarting: boolean = true;
   collectionID: string = '';
-  collectionSideMenuInitialUrlSegments: UrlSegment[];
-  collectionSideMenuInitialQueryParams: Params;
+  collSideMenuUrlSegments: UrlSegment[];
+  collSideMenuQueryParams: Params;
   currentRouterUrl: string = '';
   currentUrlSegments: UrlSegment[] = [];
   enableRouterLoadingBar: boolean = false;
@@ -66,11 +66,11 @@ export class AppComponent implements OnDestroy, OnInit {
         
         if (this.collectionID !== newCollectionID) {
           this.collectionID = newCollectionID;
-          this.tocService.setCurrentCollectionTOC(this.collectionID);
+          this.tocService.setCurrentCollectionToc(this.collectionID);
         }
 
-        this.collectionSideMenuInitialUrlSegments = this.currentUrlSegments;
-        this.collectionSideMenuInitialQueryParams = currentUrlTree?.queryParams;
+        this.collSideMenuUrlSegments = this.currentUrlSegments;
+        this.collSideMenuQueryParams = currentUrlTree?.queryParams;
         this.showCollectionSideMenu = true;
       } else {
         // If the app is started on a collection-page the main side menu

--- a/src/app/components/menus/collection-side/collection-side-menu.component.html
+++ b/src/app/components/menus/collection-side/collection-side-menu.component.html
@@ -19,7 +19,7 @@
           i18n-cancelText="@@BasicActions.Cancel"
           [interfaceOptions]="sortSelectOptions"
           (ionChange)="setActiveMenuSorting($event)"
-          [value]="activeMenuSorting"
+          [value]="activeMenuOrder"
     >
       <ion-select-option
             value="default"
@@ -39,7 +39,7 @@
       >Kategorivis</ion-select-option>
     </ion-select>
   </div>
-  <ul role="menu" [ngClass]="activeMenuSorting + '-menu-sorting'">
+  <ul role="menu" [ngClass]="activeMenuOrder + '-menu-sorting'">
     <li *ngIf="enableCover" [attr.aria-current]="routeUrlSegments[2].path === 'cover' ? 'page' : null" role="menuitem" data-id="toc_cover">
       <a routerLink="{{collectionID | collectionPagePath: 'cover'}}" [class.menu-highlight]="routeUrlSegments[2].path === 'cover'">
         <span class="label" i18n="@@CollectionCover.Cover">Omslag</span>

--- a/src/app/components/menus/collection-side/collection-side-menu.component.html
+++ b/src/app/components/menus/collection-side/collection-side-menu.component.html
@@ -40,23 +40,23 @@
     </ion-select>
   </div>
   <ul role="menu" [ngClass]="activeMenuSorting + '-menu-sorting'">
-    <li *ngIf="_config.collections?.frontMatterPages?.cover" [attr.aria-current]="initialUrlSegments[2].path === 'cover' ? 'page' : null" role="menuitem" data-id="toc_cover">
-      <a routerLink="{{collectionID | collectionPagePath: 'cover'}}" [class.menu-highlight]="initialUrlSegments[2].path === 'cover'">
+    <li *ngIf="enableCover" [attr.aria-current]="routeUrlSegments[2].path === 'cover' ? 'page' : null" role="menuitem" data-id="toc_cover">
+      <a routerLink="{{collectionID | collectionPagePath: 'cover'}}" [class.menu-highlight]="routeUrlSegments[2].path === 'cover'">
         <span class="label" i18n="@@CollectionCover.Cover">Omslag</span>
       </a>
     </li>
-    <li *ngIf="_config.collections?.frontMatterPages?.title" [attr.aria-current]="initialUrlSegments[2].path === 'title' ? 'page' : null" role="menuitem" data-id="toc_title">
-      <a routerLink="{{collectionID | collectionPagePath: 'title'}}" [class.menu-highlight]="initialUrlSegments[2].path === 'title'">
+    <li *ngIf="enableTitle" [attr.aria-current]="routeUrlSegments[2].path === 'title' ? 'page' : null" role="menuitem" data-id="toc_title">
+      <a routerLink="{{collectionID | collectionPagePath: 'title'}}" [class.menu-highlight]="routeUrlSegments[2].path === 'title'">
         <span class="label" i18n="@@CollectionTitle.TitlePage">Titelblad</span>
       </a>
     </li>
-    <li *ngIf="_config.collections?.frontMatterPages?.foreword" [attr.aria-current]="initialUrlSegments[2].path === 'foreword' ? 'page' : null" role="menuitem" data-id="toc_foreword">
-      <a routerLink="{{collectionID | collectionPagePath: 'foreword'}}" [class.menu-highlight]="initialUrlSegments[2].path === 'foreword'">
+    <li *ngIf="enableForeword" [attr.aria-current]="routeUrlSegments[2].path === 'foreword' ? 'page' : null" role="menuitem" data-id="toc_foreword">
+      <a routerLink="{{collectionID | collectionPagePath: 'foreword'}}" [class.menu-highlight]="routeUrlSegments[2].path === 'foreword'">
         <span class="label" i18n="@@CollectionForeword.Foreword">Förord</span>
       </a>
     </li>
-    <li *ngIf="_config.collections?.frontMatterPages?.introduction" [attr.aria-current]="initialUrlSegments[2].path === 'introduction' ? 'page' : null" role="menuitem" data-id="toc_introduction">
-      <a routerLink="{{collectionID | collectionPagePath: 'introduction'}}" [class.menu-highlight]="initialUrlSegments[2].path === 'introduction'">
+    <li *ngIf="enableIntroduction" [attr.aria-current]="routeUrlSegments[2].path === 'introduction' ? 'page' : null" role="menuitem" data-id="toc_introduction">
+      <a routerLink="{{collectionID | collectionPagePath: 'introduction'}}" [class.menu-highlight]="routeUrlSegments[2].path === 'introduction'">
         <span class="label" i18n="@@CollectionIntroduction.Introduction">Inledning</span>
       </a>
     </li>
@@ -68,7 +68,7 @@
   <ng-container *ngFor="let item of list">
     <li 
           [attr.data-id]="item.itemId ? 'toc_' + item.itemId : ''"
-          [attr.aria-current]="highlightedMenu === item.itemId ? 'page' : null"
+          [attr.aria-current]="currentMenuItemId === item.itemId ? 'page' : null"
           [attr.aria-haspopup]="item.children ? 'menu' : null"
           [attr.aria-expanded]="item.children ? selectedMenu.includes(item.itemId) || selectedMenu.includes(item.nodeId) : null"
           role="menuitem"
@@ -76,7 +76,7 @@
       <a *ngIf="item.itemId"
             [routerLink]="item.itemId | collectionPagePath"
             [queryParams]="item.itemId | collectionPagePositionQueryparam"
-            [class.menu-highlight]="highlightedMenu === item.itemId"
+            [class.menu-highlight]="currentMenuItemId === item.itemId"
             [class.submenu-label]="item.children"
       >
         <ng-container *ngTemplateOutlet="menuItemContent; context: {$implicit: item}"/>

--- a/src/app/components/menus/collection-side/collection-side-menu.component.ts
+++ b/src/app/components/menus/collection-side/collection-side-menu.component.ts
@@ -1,15 +1,15 @@
-import { Component, ChangeDetectorRef, Input, OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
+import { Component, Input, OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
 import { NgClass, NgFor, NgIf, NgTemplateOutlet } from '@angular/common';
 import { Params, RouterLink, UrlSegment } from '@angular/router';
 import { IonicModule } from '@ionic/angular';
+import { Subscription } from 'rxjs';
 
 import { config } from '@config';
 import { CollectionPagePathPipe } from '@pipes/collection-page-path.pipe';
 import { CollectionPagePositionQueryparamPipe } from '@pipes/collection-page-position-queryparam.pipe';
 import { CollectionTableOfContentsService } from '@services/collection-toc.service';
-import { DocumentHeadService } from '@services/document-head.service';
 import { ScrollService } from '@services/scroll.service';
-import { addOrRemoveValueInArray, flattenObjectTree, isBrowser, sortArrayOfObjectsAlphabetically, sortArrayOfObjectsNumerically } from '@utility-functions';
+import { addOrRemoveValueInArray, isBrowser } from '@utility-functions';
 
 
 @Component({
@@ -20,56 +20,64 @@ import { addOrRemoveValueInArray, flattenObjectTree, isBrowser, sortArrayOfObjec
   imports: [NgClass, NgFor, NgIf, NgTemplateOutlet, IonicModule, RouterLink, CollectionPagePathPipe, CollectionPagePositionQueryparamPipe]
 })
 export class CollectionSideMenuComponent implements OnInit, OnChanges, OnDestroy {
-  @Input() collectionID: string;
-  @Input() initialUrlSegments: UrlSegment[];
-  @Input() initialQueryParams: Params;
-  @Input() sideMenuToggled: boolean;
+  @Input() collectionID: string = '';
+  @Input() routeQueryParams: Params;
+  @Input() routeUrlSegments: UrlSegment[];
+  @Input() sideMenuToggled: boolean = true;
 
-  _config = config;
   activeMenuSorting: string = 'default';
-  alphabeticalMenu: any[] = [];
-  categoricalMenu: any[] = [];
-  chronologicalMenu: any[] = [];
   collectionMenu: any[] = [];
   collectionTitle: string = '';
-  defaultMenu: any[] = [];
-  highlightedMenu: string;
+  currentMenuItemId: string = '';
+  enableCover: boolean = false;
+  enableTitle: boolean = false;
+  enableForeword: boolean = false;
+  enableIntroduction: boolean = false;
   isLoading: boolean = true;
-  selectedMenu: string[] = [];
+  selectedMenu: string[] = []; // list of all open menu items in the menu tree
   sortOptions: string[] = [];
   sortSelectOptions: Record<string, any> = {};
+  tocSubscr: Subscription | null = null;
 
   constructor(
-    private cref: ChangeDetectorRef,
-    private headService: DocumentHeadService,
     private scrollService: ScrollService,
     private tocService: CollectionTableOfContentsService
-  ) {}
+  ) {
+    this.enableCover = config.collections?.frontMatterPages?.cover ?? false;
+    this.enableTitle = config.collections?.frontMatterPages?.title ?? false;
+    this.enableForeword = config.collections?.frontMatterPages?.foreword ?? false;
+    this.enableIntroduction = config.collections?.frontMatterPages?.introduction ?? false;
 
-  ngOnInit() {
-    this.loadMenu();
+    this.sortSelectOptions = {
+      header: $localize`:@@CollectionSideMenu.SortOptions.SelectSorting:Välj sortering för innehållsförteckningen`,
+      cssClass: 'custom-select-alert'
+    };
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    // Check if the changed input values are relevant, i.e. require the side menu to be updated.
-    // If just some other queryParams than position have changed, no action is necessary in the menu.
+    // Check if the changed input values are relevant, i.e. require the side
+    // menu to be updated. If just some other queryParams than position have
+    // changed, no action is necessary in the menu.
     for (const propName in changes) {
       if (changes.hasOwnProperty(propName)) {
         if (
           propName === 'collectionID' &&
           changes.collectionID.previousValue !== changes.collectionID.currentValue
         ) {
-          !changes.collectionID.firstChange && this.loadMenu();
+          // Collection changed, the new menu will be loaded in the subscription
+          // in ngOnInit(), so no need to do anything here.
           break;
         } else if (
           (
-            propName === 'initialUrlSegments' &&
-            JSON.stringify(changes.initialUrlSegments.previousValue) !== JSON.stringify(changes.initialUrlSegments.currentValue)
+            propName === 'routeUrlSegments' &&
+            JSON.stringify(changes.routeUrlSegments.previousValue) !== JSON.stringify(changes.routeUrlSegments.currentValue)
           ) || (
-            propName === 'initialQueryParams' &&
-            changes.initialQueryParams.previousValue.position !== changes.initialQueryParams.currentValue.position
+            propName === 'routeQueryParams' &&
+            changes.routeQueryParams.previousValue.position !== changes.routeQueryParams.currentValue.position
           )
         ) {
+          // The collection text or text position has changed, so update which
+          // menu item is highlighted.
           this.collectionMenu?.length && this.updateHighlightedMenuItem();
           break;
         } else if (
@@ -77,80 +85,63 @@ export class CollectionSideMenuComponent implements OnInit, OnChanges, OnDestroy
           changes.sideMenuToggled.previousValue !== changes.sideMenuToggled.currentValue &&
           changes.sideMenuToggled.currentValue
         ) {
+          // The side menu has been toggled visible, so scroll the menu
+          // vertically so the current menu item is visible.
           this.scrollHighlightedMenuItemIntoView(this.getItemId(), 200);
         }
       }
     }
   }
 
-  ngOnDestroy() {
-    this.tocService.setActiveTocOrder('default');
+  ngOnInit() {
+    // Subscribe to BehaviorSubject emitting the current TOC.
+    // The received TOC is already properly ordered.
+    this.tocSubscr = this.tocService.getCurrentCollectionToc().subscribe(
+      (toc: any) => {
+        this.isLoading = true;
+        this.collectionMenu = [];
+        this.selectedMenu = [];
+        this.currentMenuItemId = '';
+
+        const scrollTimeout = this.activeMenuSorting !== toc.order ? 1000 : 700;
+        this.activeMenuSorting = toc.order;
+
+        if (toc?.children?.length) {
+          this.recursiveInitializeSelectedMenu(toc.children);
+          this.collectionTitle = toc.text || '';
+          this.collectionMenu = toc.children;
+          this.isLoading = false;
+          this.updateHighlightedMenuItem(scrollTimeout);
+        }
+
+        this.sortOptions = this.setSortOptions(this.collectionID);
+      }
+    );
   }
 
-  private loadMenu() {
-    this.isLoading = true;
-    this.collectionMenu = [];
-    this.selectedMenu = [];
-    this.highlightedMenu = '';
-    this.sortOptions = this.setSortOptions(this.collectionID);
-    this.activeMenuSorting = 'default';
-    this.tocService.setActiveTocOrder('default');
-  
-    this.tocService.getTableOfContents(this.collectionID).subscribe({
-      next: (data) => {
-        if (data && data.children && data.children.length) {
-          this.recursiveInitializeSelectedMenu(data.children);
-          this.collectionTitle = data.text || '';
-          this.collectionMenu = data.children;
-          this.defaultMenu = data.children;
-          this.isLoading = false;
-          this.updateHighlightedMenuItem();
-
-          // Construct sorted menus
-          if (this.sortOptions.length > 0) {
-            const flattenedMenu = flattenObjectTree(data);
-            if (this.sortOptions.includes('alphabetical')) {
-              this.alphabeticalMenu = this.constructAlphabeticalMenu(flattenedMenu);
-            }
-            if (this.sortOptions.includes('chronological')) {
-              this.chronologicalMenu = this.constructCategoricalMenu(flattenedMenu, 'date');
-            }
-            if (this.sortOptions.includes('categorical')) {
-              const primaryKey = this._config.component?.collectionSideMenu?.categoricalSortingPrimaryKey ?? 'date';
-              const secondaryKey = this._config.component?.collectionSideMenu?.categoricalSortingSecondaryKey ?? '';
-              this.categoricalMenu = this.constructCategoricalMenu(flattenedMenu, primaryKey, secondaryKey);
-            }
-            this.sortSelectOptions = {
-              header: $localize`:@@CollectionSideMenu.SortOptions.SelectSorting:Välj sortering för innehållsförteckningen`,
-              cssClass: 'custom-select-alert'
-            }
-          }
-        }
-      }
-    });
+  ngOnDestroy() {
+    this.tocSubscr?.unsubscribe();
   }
 
   private updateHighlightedMenuItem(scrollTimeout: number = 600) {
     const itemId = this.getItemId();
-    this.highlightedMenu = itemId;
-    if (this.initialUrlSegments[2].path === 'text') {
+    this.currentMenuItemId = itemId;
+    if (this.routeUrlSegments[2].path === 'text') {
       const item = this.recursiveFindMenuItem(this.collectionMenu, itemId);
       if (item && !this.selectedMenu.includes(item.itemId || item.nodeId)) {
         this.selectedMenu.push(item.itemId || item.nodeId);
       }
     }
-    // Angular is not good at detecting changes within arrays and objects, so we have to manually trigger an update of the view
-    this.cref.detectChanges();
     this.scrollHighlightedMenuItemIntoView(itemId, scrollTimeout);
   }
 
   private getItemId(): string {
     let itemId = '';
-    itemId += this.initialUrlSegments[1]?.path ? `${this.initialUrlSegments[1].path}` : '';
-    itemId += this.initialUrlSegments[3]?.path ? `_${this.initialUrlSegments[3].path}` : '';
-    itemId += this.initialUrlSegments[4]?.path ? `_${this.initialUrlSegments[4].path}` : '';
+    itemId += this.routeUrlSegments[1]?.path ? `${this.routeUrlSegments[1].path}` : '';
+    itemId += this.routeUrlSegments[3]?.path ? `_${this.routeUrlSegments[3].path}` : '';
+    itemId += this.routeUrlSegments[4]?.path ? `_${this.routeUrlSegments[4].path}` : '';
 
-    itemId += this.initialQueryParams.position ? `;${this.initialQueryParams.position}` : '';
+    itemId += this.routeQueryParams.position ? `;${this.routeQueryParams.position}` : '';
     return itemId;
   }
 
@@ -158,10 +149,6 @@ export class CollectionSideMenuComponent implements OnInit, OnChanges, OnDestroy
    * Recursively search array for an object that has an 'itemId' property
    * equal to 'searchItemId'. If found, the item is marked as the selected
    * item in the side menu.
-   * @param array 
-   * @param searchItemId 
-   * @param setTitleOnly if true, the matching item is not set as selected
-   * in the menu, it's title is just set as the page title.
    */
   private recursiveFindMenuItem(array: any[], searchItemId: string): any {
     return array.find(item => {
@@ -205,16 +192,23 @@ export class CollectionSideMenuComponent implements OnInit, OnChanges, OnDestroy
     }
   }
 
-  private scrollHighlightedMenuItemIntoView(itemId: string, scrollTimeout: number = 600) {
+  private scrollHighlightedMenuItemIntoView(
+    itemId: string,
+    scrollTimeout: number = 600
+  ) {
     if (isBrowser()) {
       setTimeout(() => {
-        const dataIdValue = this.initialUrlSegments[2].path === 'text'
+        const dataIdValue = this.routeUrlSegments[2].path === 'text'
               ? 'toc_' + itemId
-              : 'toc_' + this.initialUrlSegments[2].path;
+              : 'toc_' + this.routeUrlSegments[2].path;
         const container = document.querySelector('.side-navigation') as HTMLElement;
-        const target = document.querySelector('collection-side-menu [data-id="' + dataIdValue + '"] .menu-highlight') as HTMLElement;
+        const target = document.querySelector(
+          'collection-side-menu [data-id="' + dataIdValue + '"] .menu-highlight'
+        ) as HTMLElement;
         if (container && target) {
-          this.scrollService.scrollElementIntoView(target, 'center', 0, 'smooth', container);
+          this.scrollService.scrollElementIntoView(
+            target, 'center', 0, 'smooth', container
+          );
         }
       }, scrollTimeout);
     }
@@ -222,120 +216,30 @@ export class CollectionSideMenuComponent implements OnInit, OnChanges, OnDestroy
 
   private setSortOptions(collectionID: string) {
     const sortOptions: string[] = [];
-    if (this._config.component?.collectionSideMenu?.sortableCollectionsAlphabetical?.includes(collectionID)) {
+    if (config.component?.collectionSideMenu?.
+            sortableCollectionsAlphabetical?.includes(collectionID)) {
       sortOptions.push('alphabetical');
     }
-    if (this._config.component?.collectionSideMenu?.sortableCollectionsChronological?.includes(collectionID)) {
+    if (config.component?.collectionSideMenu?.
+            sortableCollectionsChronological?.includes(collectionID)) {
       sortOptions.push('chronological');
     }
-    if (this._config.component?.collectionSideMenu?.sortableCollectionsCategorical?.includes(collectionID)) {
+    if (config.component?.collectionSideMenu?.
+            sortableCollectionsCategorical?.includes(collectionID)) {
       sortOptions.push('categorical');
     }
     return sortOptions;
-  }
-
-  /** Has been copied to toc-service, should be used from there */
-  private constructAlphabeticalMenu(flattenedMenuData: any[]) {
-    const alphabeticalMenu: any[] = [];
-
-    for (const child of flattenedMenuData) {
-      if (child.itemId) {
-        alphabeticalMenu.push(child);
-      }
-    }
-
-    sortArrayOfObjectsAlphabetically(alphabeticalMenu, 'text');
-    return alphabeticalMenu;
-  }
-
-  private constructCategoricalMenu(flattenedMenuData: any[], primarySortKey: string, secondarySortKey?: string) {
-    const orderedList: any[] = [];
-
-    for (const child of flattenedMenuData) {
-      if (
-        child[primarySortKey] &&
-        ((secondarySortKey && child[secondarySortKey]) || !secondarySortKey) &&
-        child.itemId
-      ) {
-        orderedList.push(child);
-      }
-    }
-
-    if (primarySortKey === 'date') {
-      sortArrayOfObjectsNumerically(orderedList, primarySortKey, 'asc');
-    } else {
-      sortArrayOfObjectsAlphabetically(orderedList, primarySortKey);
-    }
-
-    const categoricalMenu: any[] = [];
-    let childItems: any[] = [];
-    let prevCategory = '';
-
-    for (let i = 0; i < orderedList.length; i++) {
-      let currentCategory = orderedList[i][primarySortKey];
-      if (primarySortKey === 'date') {
-        currentCategory = String(currentCategory).split('-')[0];
-      }
-
-      if (prevCategory === '') {
-        prevCategory = currentCategory;
-        categoricalMenu.push({type: 'subtitle', collapsed: true, text: prevCategory, children: []});
-      }
-
-      if (prevCategory !== currentCategory) {
-        if (secondarySortKey === 'date') {
-          sortArrayOfObjectsNumerically(childItems, secondarySortKey, 'asc');
-        } else if (secondarySortKey) {
-          sortArrayOfObjectsAlphabetically(childItems, secondarySortKey);
-        }
-        categoricalMenu[categoricalMenu.length - 1].children = childItems;
-        childItems = [];
-        prevCategory = currentCategory;
-        categoricalMenu.push({type: 'subtitle', collapsed: true, text: prevCategory, children: []});
-      }
-      childItems.push(orderedList[i]);
-    }
-
-    if (childItems.length > 0) {
-      if (secondarySortKey === 'date') {
-        sortArrayOfObjectsNumerically(childItems, secondarySortKey, 'asc');
-      } else if (secondarySortKey) {
-        sortArrayOfObjectsAlphabetically(childItems, secondarySortKey);
-      }
-    }
-
-    if (categoricalMenu.length > 0) {
-      categoricalMenu[categoricalMenu.length - 1].children = childItems;
-    } else {
-      categoricalMenu[0] = {};
-      categoricalMenu[0].children = childItems;
-    }
-
-    return categoricalMenu;
   }
 
   toggle(menuItem: any) {
     addOrRemoveValueInArray(this.selectedMenu, menuItem.itemId || menuItem.nodeId);
   }
 
-  setActiveMenuSorting(event: any) {
+  async setActiveMenuSorting(event: any) {
     if (this.activeMenuSorting !== event.detail.value) {
-      this.activeMenuSorting = event.detail.value;
-      this.tocService.setActiveTocOrder(event.detail.value);
-      this.selectedMenu = [];
-
-      if (this.activeMenuSorting === 'alphabetical') {
-        this.collectionMenu = this.alphabeticalMenu;
-      } else if (this.activeMenuSorting === 'chronological') {
-        this.collectionMenu = this.chronologicalMenu;
-      } else if (this.activeMenuSorting === 'categorical') {
-        this.collectionMenu = this.categoricalMenu;
-      } else {
-        this.collectionMenu = this.defaultMenu;
-      }
-
-      this.recursiveInitializeSelectedMenu(this.collectionMenu);
-      this.updateHighlightedMenuItem(800);
+      this.tocService.setCurrentCollectionToc(
+        this.collectionID, event.detail.value
+      );
     }
   }
 

--- a/src/app/components/menus/collection-side/collection-side-menu.component.ts
+++ b/src/app/components/menus/collection-side/collection-side-menu.component.ts
@@ -25,7 +25,7 @@ export class CollectionSideMenuComponent implements OnInit, OnChanges, OnDestroy
   @Input() routeUrlSegments: UrlSegment[];
   @Input() sideMenuToggled: boolean = true;
 
-  activeMenuSorting: string = 'default';
+  activeMenuOrder: string = '';
   collectionMenu: any[] = [];
   collectionTitle: string = '';
   currentMenuItemId: string = '';
@@ -103,8 +103,8 @@ export class CollectionSideMenuComponent implements OnInit, OnChanges, OnDestroy
         this.selectedMenu = [];
         this.currentMenuItemId = '';
 
-        const scrollTimeout = this.activeMenuSorting !== toc.order ? 1000 : 700;
-        this.activeMenuSorting = toc.order;
+        const scrollTimeout = this.activeMenuOrder !== toc?.order ? 1000 : 700;
+        this.activeMenuOrder = toc?.order || 'default';
 
         if (toc?.children?.length) {
           this.recursiveInitializeSelectedMenu(toc.children);
@@ -236,7 +236,7 @@ export class CollectionSideMenuComponent implements OnInit, OnChanges, OnDestroy
   }
 
   async setActiveMenuSorting(event: any) {
-    if (this.activeMenuSorting !== event.detail.value) {
+    if (this.activeMenuOrder !== event.detail.value) {
       this.tocService.setCurrentCollectionToc(
         this.collectionID, event.detail.value
       );

--- a/src/app/components/menus/collection-side/collection-side-menu.component.ts
+++ b/src/app/components/menus/collection-side/collection-side-menu.component.ts
@@ -133,8 +133,7 @@ export class CollectionSideMenuComponent implements OnInit, OnChanges, OnDestroy
   private updateHighlightedMenuItem(scrollTimeout: number = 600) {
     const itemId = this.getItemId();
     this.highlightedMenu = itemId;
-    const isFrontMatterPage = this.setTitleForFrontMatterPages();
-    if (!isFrontMatterPage) {
+    if (this.initialUrlSegments[2].path === 'text') {
       const item = this.recursiveFindMenuItem(this.collectionMenu, itemId);
       if (item && !this.selectedMenu.includes(item.itemId || item.nodeId)) {
         this.selectedMenu.push(item.itemId || item.nodeId);
@@ -143,26 +142,6 @@ export class CollectionSideMenuComponent implements OnInit, OnChanges, OnDestroy
     // Angular is not good at detecting changes within arrays and objects, so we have to manually trigger an update of the view
     this.cref.detectChanges();
     this.scrollHighlightedMenuItemIntoView(itemId, scrollTimeout);
-  }
-
-  private setTitleForFrontMatterPages() {
-    const page = this.initialUrlSegments[2].path;
-    switch (page) {
-      case 'cover':
-        this.headService.setTitle([$localize`:@@CollectionCover.Cover:Omslag`, this.collectionTitle]);
-        return true;
-      case 'title':
-        this.headService.setTitle([$localize`:@@CollectionTitle.TitlePage:Titelblad`, this.collectionTitle]);
-        return true;
-      case 'foreword':
-        this.headService.setTitle([$localize`:@@CollectionForeword.Foreword:Förord`, this.collectionTitle]);
-        return true;
-      case 'introduction':
-        this.headService.setTitle([$localize`:@@CollectionIntroduction.Introduction:Inledning`, this.collectionTitle]);
-        return true;
-      default:
-        return false;
-    }
   }
 
   private getItemId(): string {
@@ -177,37 +156,20 @@ export class CollectionSideMenuComponent implements OnInit, OnChanges, OnDestroy
 
   /**
    * Recursively search array for an object that has an 'itemId' property
-   * equal to 'searchItemId'. If found, the page title is set to the item's
-   * title and the item is marked as the selected item in the side menu.
+   * equal to 'searchItemId'. If found, the item is marked as the selected
+   * item in the side menu.
    * @param array 
    * @param searchItemId 
    * @param setTitleOnly if true, the matching item is not set as selected
    * in the menu, it's title is just set as the page title.
    */
-  private recursiveFindMenuItem(
-    array: any[],
-    searchItemId: string,
-    setTitleOnly: boolean = false
-  ): any {
+  private recursiveFindMenuItem(array: any[], searchItemId: string): any {
     return array.find(item => {
       if (item.itemId === searchItemId) {
-        if (item.itemId.split(';')[1]) {
-          // The itemId contains a position, so we need to find it's parent
-          // that doesn't contain a position, since we don't want positioned
-          // item's titles to be set as page titles.
-          this.recursiveFindMenuItem(
-            this.collectionMenu, item.itemId.split(';')[0], true
-          );
-        } else {
-          this.headService.setTitle([String(item.text), this.collectionTitle]);
-        }
         return item;
       } else if (item.children) {
-        const result = this.recursiveFindMenuItem(
-          item.children, searchItemId, setTitleOnly
-        );
+        const result = this.recursiveFindMenuItem(item.children, searchItemId);
         if (
-          !setTitleOnly &&
           result &&
           !this.selectedMenu.includes(result.itemId || result.nodeId)
         ) {
@@ -272,6 +234,7 @@ export class CollectionSideMenuComponent implements OnInit, OnChanges, OnDestroy
     return sortOptions;
   }
 
+  /** Has been copied to toc-service, should be used from there */
   private constructAlphabeticalMenu(flattenedMenuData: any[]) {
     const alphabeticalMenu: any[] = [];
 

--- a/src/app/components/text-changer/text-changer.component.html
+++ b/src/app/components/text-changer/text-changer.component.html
@@ -4,28 +4,30 @@
       [class.desktop-mode]="!mobileMode"
 >
   <div class="prev-wrapper">
-    <button *ngIf="currentTocTextIndex > 0"
+    <a *ngIf="currentTocTextIndex > 0"
           class="prev-button"
-          (click)="openText(currentTocTextIndex - 1)"
+          [routerLink]="flattenedToc[currentTocTextIndex - 1].itemId | collectionPagePath: flattenedToc[currentTocTextIndex - 1].page"
+          [queryParams]="flattenedToc[currentTocTextIndex - 1].itemId | collectionPagePositionQueryparam"
     >
       <ion-icon name="arrow-back"></ion-icon>
       <span *ngIf="!mobileMode" class="prev-text-name">
         {{flattenedToc[currentTocTextIndex - 1].text}}
       </span>
-    </button>
+    </a>
   </div>
   <div class="current-text-name">
     <p>{{flattenedToc[currentTocTextIndex].text}} {{flattenedToc[currentTocTextIndex].text_two || ''}}</p>
   </div>
   <div class="next-wrapper">
-    <button *ngIf="currentTocTextIndex < flattenedToc.length - 1"
+    <a *ngIf="currentTocTextIndex < flattenedToc.length - 1"
           class="next-button"
-          (click)="openText(currentTocTextIndex + 1)"
+          [routerLink]="flattenedToc[currentTocTextIndex + 1].itemId | collectionPagePath: flattenedToc[currentTocTextIndex + 1].page"
+          [queryParams]="flattenedToc[currentTocTextIndex + 1].itemId | collectionPagePositionQueryparam"
     >
       <span *ngIf="!mobileMode" class="next-text-name">
         {{flattenedToc[currentTocTextIndex + 1].text}}
       </span>
       <ion-icon name="arrow-forward"></ion-icon>
-    </button>
+    </a>
   </div>
 </div>

--- a/src/app/components/text-changer/text-changer.component.html
+++ b/src/app/components/text-changer/text-changer.component.html
@@ -1,16 +1,30 @@
-<div class="text-changer-wrapper" [class.mobile-mode]="mobileMode" [class.desktop-mode]="!mobileMode">
+<div *ngIf="flattenedToc.length"
+      class="text-changer-wrapper"
+      [class.mobile-mode]="mobileMode"
+      [class.desktop-mode]="!mobileMode"
+>
   <div class="prev-wrapper">
-    <button *ngIf="!firstItem" class="prev-button" (click)="previous()">
+    <button *ngIf="currentTocTextIndex > 0"
+          class="prev-button"
+          (click)="openText(currentTocTextIndex - 1)"
+    >
       <ion-icon name="arrow-back"></ion-icon>
-      <span *ngIf="!mobileMode" class="prev-text-name">{{ prevItemTitle }}</span>
+      <span *ngIf="!mobileMode" class="prev-text-name">
+        {{flattenedToc[currentTocTextIndex - 1].text}}
+      </span>
     </button>
   </div>
   <div class="current-text-name">
-    <p>{{ currentItemTitle }}</p>
+    <p>{{flattenedToc[currentTocTextIndex].text}} {{flattenedToc[currentTocTextIndex].text_two || ''}}</p>
   </div>
   <div class="next-wrapper">
-    <button *ngIf="!lastItem" class="next-button" (click)="next()">
-      <span *ngIf="!mobileMode" class="next-text-name">{{ nextItemTitle }}</span>
+    <button *ngIf="currentTocTextIndex < flattenedToc.length - 1"
+          class="next-button"
+          (click)="openText(currentTocTextIndex + 1)"
+    >
+      <span *ngIf="!mobileMode" class="next-text-name">
+        {{flattenedToc[currentTocTextIndex + 1].text}}
+      </span>
       <ion-icon name="arrow-forward"></ion-icon>
     </button>
   </div>

--- a/src/app/components/text-changer/text-changer.component.scss
+++ b/src/app/components/text-changer/text-changer.component.scss
@@ -54,16 +54,16 @@
     white-space: nowrap;
   }
 
-  button {
+  a {
     align-items: center;
-    background: transparent;
     color: inherit;
     display: flex;
     height: 100%;
     hyphens: auto;
     outline-offset: -0.125rem;
     overflow: hidden;
-    padding: 0 6px;
+    padding: 0 0.375rem;
+    text-decoration: none;
     width: 100%;
 
     > span {
@@ -109,7 +109,7 @@
       max-width: 100%;
     }
 
-    button {
+    a {
       &:hover {
         opacity: 0.6;
         transition: opacity 0.2s;
@@ -135,7 +135,7 @@
 .text-changer-wrapper.mobile-mode {
   justify-content: space-between;
 
-  button {
+  a {
     padding: 0 10px;
   }
 

--- a/src/app/components/text-changer/text-changer.component.ts
+++ b/src/app/components/text-changer/text-changer.component.ts
@@ -1,86 +1,56 @@
 import { Component, Input, OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
 import { NgIf } from '@angular/common';
-import { Router } from '@angular/router';
+import { RouterLink } from '@angular/router';
 import { IonicModule } from '@ionic/angular';
-import { Subscription } from 'rxjs';
+import { combineLatest, distinctUntilChanged, Subscription } from 'rxjs';
 
 import { config } from '@config';
 import { CollectionTableOfContentsService } from '@services/collection-toc.service';
 import { DocumentHeadService } from '@services/document-head.service';
+import { CollectionPagePathPipe } from '@pipes/collection-page-path.pipe';
+import { CollectionPagePositionQueryparamPipe } from '@pipes/collection-page-position-queryparam.pipe';
 import { PlatformService } from '@services/platform.service';
-import { sortArrayOfObjectsAlphabetically, sortArrayOfObjectsNumerically } from '@utility-functions';
 
 
+/**
+ * Component for displaying the title of the current collection page as well
+ * as links to the previous and next collection page based on the collection
+ * menu/table of contents. This component is responsible for setting the 
+ * document title to the title of the current text for collection pages.
+ * Thus this component must always be server-side rendered.
+ */
 @Component({
   standalone: true,
   selector: 'text-changer',
   templateUrl: './text-changer.component.html',
   styleUrls: ['./text-changer.component.scss'],
-  imports: [NgIf, IonicModule]
+  imports: [NgIf, RouterLink, IonicModule, CollectionPagePathPipe, CollectionPagePositionQueryparamPipe]
 })
 export class TextChangerComponent implements OnChanges, OnDestroy, OnInit {
   @Input() parentPageType: string = '';
   @Input() textItemID: string = '';
   @Input() textPosition: string = '';
 
-  activeTocOrder: string = 'default';
-  activeTocOrderSubscr: Subscription | null = null;
-  collectionHasCover: boolean = false;
-  collectionHasTitle: boolean = false;
-  collectionHasForeword: boolean = false;
-  collectionHasIntro: boolean = false;
+  activeTocOrder: string = '';
+  categoricalTocPrimarySortKey: string = 'date';
+  categoricalTocSecondarySortKey: string = '';
   collectionId: string = '';
   collectionTitle: string = '';
-  currentItemTitle: string = '';
-  firstItem?: boolean;
+  currentTocTextIndex: number = 0;
   flattenedToc: any[] = [];
-  lastItem?: boolean;
+  frontMatterPages: any[] = [];
   mobileMode: boolean = false;
-  nextItem: any;
-  nextItemTitle?: string;
-  prevItem: any;
-  prevItemTitle?: string;
   tocItemId: string = '';
   tocSubscr: Subscription | null = null;
-
-  frontMatterPages: any[] = [];
-  currentTocTextIndex: number = 0;
+  unsortedFlattenedToc: any[] = [];
 
   constructor(
     private headService: DocumentHeadService,
     private platformService: PlatformService,
-    private router: Router,
     private tocService: CollectionTableOfContentsService
   ) {
-    this.collectionHasCover = config.collections?.frontMatterPages?.cover ?? false;
-    this.collectionHasTitle = config.collections?.frontMatterPages?.title ?? false;
-    this.collectionHasForeword = config.collections?.frontMatterPages?.foreword ?? false;
-    this.collectionHasIntro = config.collections?.frontMatterPages?.introduction ?? false;
-
-    if (config.collections?.frontMatterPages?.cover) {
-      this.frontMatterPages.push({
-        text: $localize`:@@CollectionCover.Cover:Omslag`,
-        page: 'cover'
-      });
-    }
-    if (config.collections?.frontMatterPages?.title) {
-      this.frontMatterPages.push({
-        text: $localize`:@@CollectionTitle.TitlePage:Titelblad`,
-        page: 'title'
-      });
-    }
-    if (config.collections?.frontMatterPages?.foreword) {
-      this.frontMatterPages.push({
-        text: $localize`:@@CollectionForeword.Foreword:Förord`,
-        page: 'foreword'
-      });
-    }
-    if (config.collections?.frontMatterPages?.introduction) {
-      this.frontMatterPages.push({
-        text: $localize`:@@CollectionIntroduction.Introduction:Inledning`,
-        page: 'introduction'
-      });
-    }
+    this.categoricalTocPrimarySortKey = config.component?.collectionSideMenu?.categoricalSortingPrimaryKey ?? 'date';
+    this.categoricalTocSecondarySortKey = config.component?.collectionSideMenu?.categoricalSortingSecondaryKey ?? '';
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -103,101 +73,141 @@ export class TextChangerComponent implements OnChanges, OnDestroy, OnInit {
       }
     }
 
-    if (!this.parentPageType) {
-      this.parentPageType = 'page-text';
-    }
-
-    this.collectionId = this.textItemID.split('_')[0];
-    this.tocItemId = this.textItemID;
-    if (this.textPosition) {
-      this.tocItemId += ';' + this.textPosition;
-    }
-
     if (!firstChange) {
-      console.log('changing from ngChanges');
+      this.updateVariables();
       this.updateCurrentText();
     }
-
-    /*
-    if (
-      !firstChange &&
-      this.parentPageType === 'page-text' &&
-      (
-        changes.textItemID === undefined ||
-        this.textItemID === changes.textItemID.previousValue
-      ) &&
-      changes.textPosition &&
-      this.textPosition !== changes.textPosition.previousValue
-    ) {
-      // Same read text, different text position
-      this.setCurrentPreviousAndNextItemsFromFlattenedToc(this.tocItemId);
-    } else if (
-      !firstChange &&
-      this.parentPageType === 'page-text' &&
-      this.flattenedToc.length > 0 &&
-      changes.textItemID &&
-      this.collectionId === changes.textItemID.previousValue.split('_')[0]
-    ) {
-      // Different read text, same collection
-      this.setCurrentPreviousAndNextItemsFromFlattenedToc(this.tocItemId);
-    } else if (
-      !firstChange &&
-      this.parentPageType !== 'page-text' &&
-      this.collectionId === changes.textItemID.previousValue.split('_')[0]
-    ) {
-      // Different parent page type, same collection
-      this.setItems();
-    } else if (!firstChange) {
-      // Different collection or parent page type
-      this.loadData();
-    }
-    */
   }
 
   ngOnInit() {
-    console.log('text changer init', this.textItemID);
     this.mobileMode = this.platformService.isMobile();
+    this.updateVariables();
+    this.setFrontmatterPagesArray();
 
-    this.activeTocOrderSubscr = this.tocService.getActiveTocOrder().subscribe(
-      (tocOrder: string) => {
-        if (
-          tocOrder !== this.activeTocOrder &&
-          this.flattenedToc.length &&
-          this.textItemID
-        ) {
+    // Subscribe to BehaviorSubjects emitting the current sorting of
+    // the collection TOC as well as the flattened TOC itself.
+    // TODO: explore how sorted flattened TOCs could be cached so they
+    // TODO: don't need to be recreated on every text change.
+    this.tocSubscr = combineLatest([
+      this.tocService.getActiveTocOrder().pipe(distinctUntilChanged()),
+      this.tocService.getCurrentFlattenedCollectionTOC()
+    ]).subscribe(([tocOrder, toc]) => {
+      if (
+        toc?.children?.length &&
+        this.collectionId === toc?.collectionId
+      ) {
+        this.collectionTitle = toc.text || '';
+        this.unsortedFlattenedToc = toc.children;
+        let sortedToc = toc.children;
+        if (tocOrder !== this.activeTocOrder) {
           this.activeTocOrder = tocOrder;
-          
+          if (
+            this.activeTocOrder === 'alphabetical' &&
+            config.component?.collectionSideMenu?.sortableCollectionsAlphabetical?.includes(this.collectionId)
+          ) {
+            sortedToc = this.tocService.constructAlphabeticalMenu(toc.children);
+          } else if (
+            this.activeTocOrder === 'chronological' &&
+            config.component?.collectionSideMenu?.sortableCollectionsChronological?.includes(this.collectionId)
+          ) {
+            sortedToc = this.tocService.constructCategoricalMenu(
+              toc.children, 'date', undefined, true
+            );
+          } else if (
+            this.activeTocOrder === 'categorical' &&
+            config.component?.collectionSideMenu?.sortableCollectionsCategorical?.includes(this.collectionId)
+          ) {
+            sortedToc = this.tocService.constructCategoricalMenu(
+              toc.children,
+              this.categoricalTocPrimarySortKey,
+              this.categoricalTocSecondarySortKey,
+              true
+            )
+          } else if (this.unsortedFlattenedToc.length) {
+            sortedToc = this.unsortedFlattenedToc;
+          }
         }
+        // Prepend the frontmatter pages to the TOC array
+        this.flattenedToc = this.frontMatterPages.concat(sortedToc);
+        // Search for the current text in the array and display it
+        this.updateCurrentText();
       }
-    );
-
-    this.tocSubscr = this.tocService.getCurrentFlattenedCollectionTOC().subscribe(
-      (toc: any[]) => {
-        if (
-          toc.length &&
-          this.collectionId === toc[0].itemId.split('_')[0]
-        ) {
-          this.flattenedToc = this.frontMatterPages.concat(toc);
-          this.updateCurrentText();
-        }
-      }
-    );
+    });
   }
 
   ngOnDestroy() {
-    this.activeTocOrderSubscr?.unsubscribe();
     this.tocSubscr?.unsubscribe();
   }
 
+  private updateVariables() {
+    if (!this.parentPageType) {
+      this.parentPageType = 'text';
+    }
+
+    this.collectionId = this.textItemID.split('_')[0];
+    this.tocItemId = this.textPosition
+          ? this.textItemID + ';' + this.textPosition
+          : this.textItemID;
+  }
+
+  private setFrontmatterPagesArray() {
+    if (config.collections?.frontMatterPages?.cover) {
+      this.frontMatterPages.push({
+        text: $localize`:@@CollectionCover.Cover:Omslag`,
+        page: 'cover',
+        itemId: this.collectionId
+      });
+    }
+    if (config.collections?.frontMatterPages?.title) {
+      this.frontMatterPages.push({
+        text: $localize`:@@CollectionTitle.TitlePage:Titelblad`,
+        page: 'title',
+        itemId: this.collectionId
+      });
+    }
+    if (config.collections?.frontMatterPages?.foreword) {
+      this.frontMatterPages.push({
+        text: $localize`:@@CollectionForeword.Foreword:Förord`,
+        page: 'foreword',
+        itemId: this.collectionId
+      });
+    }
+    if (config.collections?.frontMatterPages?.introduction) {
+      this.frontMatterPages.push({
+        text: $localize`:@@CollectionIntroduction.Introduction:Inledning`,
+        page: 'introduction',
+        itemId: this.collectionId
+      });
+    }
+  }
+
+  /**
+   * Updates the text that's displayed as the current text (as well as the
+   * previous and next text), and sets the document title to the current
+   * text title. If the current text is a positioned heading in a longer
+   * text, the patent text title is set as the document title.
+   */
   private updateCurrentText() {
     const foundTextIndex = this.getCurrentTextIndex();
     if (foundTextIndex > -1) {
-      console.log(this.flattenedToc[foundTextIndex]);
       this.currentTocTextIndex = foundTextIndex;
     } else {
       console.error('Unable to find the current text in flattenedTOC in text-changer component.');
       this.currentTocTextIndex = 0;
     }
+
+    // Set the document title to the current text title.
+    // Positioned item's title should not be set, instead we have to
+    // search for the non-positioned item's title.
+    let titleItemIndex = this.currentTocTextIndex;
+    if (this.textPosition) {
+      titleItemIndex = this.flattenedToc.findIndex(
+        ({ itemId }) => itemId === this.textItemID
+      );
+    }
+    this.headService.setTitle([
+      this.flattenedToc[titleItemIndex].text || '', this.collectionTitle
+    ]);
   }
 
   private getCurrentTextIndex() {
@@ -214,508 +224,6 @@ export class TextChangerComponent implements OnChanges, OnDestroy, OnInit {
       }
     }
     return currentTextIndex;
-  }
-
-  openText(tocIndex: number) {
-    const item = this.flattenedToc[tocIndex];
-    if (item.page !== undefined) {
-      // Open text in page-cover, page-title, page-foreword or page-introduction
-      this.router.navigate(['/collection', this.collectionId, item.page]);
-    } else {
-      // Open text in page-text
-      let itemIdParts = item.itemId.split(';');
-      const positionId = itemIdParts.length > 1 ? itemIdParts[1] : '';
-      itemIdParts = itemIdParts[0].split('_');
-      const collectionId = itemIdParts[0];
-      const publicationId = itemIdParts[1];
-      const chapterId = itemIdParts.length > 2 ? itemIdParts[2] : '';
-
-      this.router.navigate(
-        (
-          chapterId ? ['/collection', collectionId, 'text', publicationId, chapterId] :
-          ['/collection', collectionId, 'text', publicationId]
-        ),
-        (positionId ? { queryParams: { position: positionId } } : {})
-      );
-    }
-  }
-
-  private loadData() {
-    this.flattenedToc = [];
-    this.setItems();
-  }
-
-  private setItems() {
-    if (this.parentPageType === 'page-cover') {
-      // Initialised from page-cover
-      this.currentItemTitle = $localize`:@@CollectionCover.Cover:Omslag`;
-
-      this.firstItem = true;
-      this.lastItem = false;
-      if (this.collectionHasTitle) {
-        this.setPageTitleAsNext(this.collectionId);
-      } else if (this.collectionHasForeword) {
-        this.setPageForewordAsNext(this.collectionId);
-      } else if (this.collectionHasIntro) {
-        this.setPageIntroductionAsNext(this.collectionId);
-      } else {
-        this.setFirstTocItemAsNext(this.collectionId);
-      }
-
-    } else if (this.parentPageType === 'page-title') {
-      // Initialised from page-title
-      this.currentItemTitle = $localize`:@@CollectionTitle.TitlePage:Titelblad`;
-
-      if (this.collectionHasCover) {
-        this.firstItem = false;
-        this.setPageCoverAsPrevious(this.collectionId);
-      } else {
-        this.firstItem = true;
-      }
-
-      this.lastItem = false;
-      if (this.collectionId === 'mediaCollections') {
-        this.setMediaCollectionsAsNext();
-      } else {
-        if (this.collectionHasForeword) {
-          this.setPageForewordAsNext(this.collectionId);
-        } else if (this.collectionHasIntro) {
-          this.setPageIntroductionAsNext(this.collectionId);
-        } else {
-          this.setFirstTocItemAsNext(this.collectionId);
-        }
-      }
-
-    } else if (this.parentPageType === 'page-foreword') {
-      // Initialised from page-foreword
-      this.currentItemTitle = $localize`:@@CollectionForeword.Foreword:Förord`;
-
-      this.lastItem = false;
-      if (this.collectionHasCover || this.collectionHasTitle) {
-        this.firstItem = false;
-      } else {
-        this.firstItem = true;
-      }
-
-      if (this.collectionHasTitle) {
-        this.setPageTitleAsPrevious(this.collectionId);
-      } else if (this.collectionHasCover) {
-        this.setPageCoverAsPrevious(this.collectionId);
-      }
-
-      if (this.collectionHasIntro) {
-        this.setPageIntroductionAsNext(this.collectionId);
-      } else {
-        this.setFirstTocItemAsNext(this.collectionId);
-      }
-
-    } else if (this.parentPageType === 'page-introduction') {
-      // Initialised from page-introduction
-      this.currentItemTitle = $localize`:@@CollectionIntroduction.Introduction:Inledning`;
-
-      this.lastItem = false;
-      if (this.collectionHasCover || this.collectionHasTitle || this.collectionHasForeword) {
-        this.firstItem = false;
-      } else {
-        this.firstItem = true;
-      }
-
-      if (this.collectionHasForeword) {
-        this.setPageForewordAsPrevious(this.collectionId);
-      } else if (this.collectionHasTitle) {
-        this.setPageTitleAsPrevious(this.collectionId);
-      } else if (this.collectionHasCover) {
-        this.setPageCoverAsPrevious(this.collectionId);
-      }
-      this.setFirstTocItemAsNext(this.collectionId);
-
-    } else {
-      // Default functionality, e.g. as when initialised from page-text
-      this.firstItem = false;
-      this.lastItem = false;
-      this.next(true);
-    }
-  }
-
-  setFirstTocItemAsNext(collectionId: string) {
-    try {
-      this.tocService.getTableOfContents(collectionId).subscribe(
-        (toc: any) => {
-          if (toc && toc.children && String(toc.collectionId) === collectionId) {
-            this.flatten(toc);
-            if (this.activeTocOrder === 'alphabetical') {
-              this.sortFlattenedTocAlphabetically();
-            } else if (this.activeTocOrder === 'chronological') {
-              this.sortFlattenedTocChronologically();
-            } else if (this.activeTocOrder === 'categorical') {
-              this.sortFlattenedTocCategorically();
-            }
-            for (let i = 0; i < this.flattenedToc.length; i++) {
-              if (
-                this.flattenedToc[i].itemId !== undefined &&
-                this.flattenedToc[i].type !== 'subtitle' &&
-                this.flattenedToc[i].type !== 'section_title'
-              ) {
-                this.nextItemTitle = this.flattenedToc[i].text;
-                this.nextItem = this.flattenedToc[i];
-                break;
-              }
-            }
-          } else {
-            this.nextItemTitle = '';
-            this.nextItem = null;
-            this.lastItem = true;
-          }
-        }
-      );
-    } catch (e) {
-      console.log('Unable to get first toc item as next in text-changer');
-      this.nextItemTitle = '';
-      this.nextItem = null;
-      this.lastItem = true;
-    }
-  }
-
-  setPageTitleAsNext(collectionId: string) {
-    this.nextItemTitle = $localize`:@@CollectionTitle.TitlePage:Titelblad`;
-    this.nextItem = {
-      itemId: collectionId,
-      page: 'page-title'
-    };
-  }
-
-  setPageForewordAsNext(collectionId: string) {
-    this.nextItemTitle = $localize`:@@CollectionForeword.Foreword:Förord`;
-    this.nextItem = {
-      itemId: collectionId,
-      page: 'page-foreword'
-    };
-  }
-
-  setPageIntroductionAsNext(collectionId: string) {
-    this.nextItemTitle = $localize`:@@CollectionIntroduction.Introduction:Inledning`;
-    this.nextItem = {
-      itemId: collectionId,
-      page: 'page-introduction'
-    };
-  }
-
-  setMediaCollectionsAsNext() {
-    this.nextItemTitle = '';
-    this.nextItem = {
-      itemId: 'mediaCollections',
-      page: 'media-collection'
-    };
-  }
-
-  setPageCoverAsPrevious(collectionId: string) {
-    this.prevItemTitle = $localize`:@@CollectionCover.Cover:Omslag`;
-    this.prevItem = {
-      itemId: collectionId,
-      page: 'page-cover'
-    };
-  }
-
-  setPageTitleAsPrevious(collectionId: string) {
-    this.prevItemTitle = $localize`:@@CollectionTitle.TitlePage:Titelblad`;
-    this.prevItem = {
-      itemId: collectionId,
-      page: 'page-title'
-    };
-  }
-
-  setPageForewordAsPrevious(collectionId: string) {
-    this.prevItemTitle = $localize`:@@CollectionForeword.Foreword:Förord`;
-    this.prevItem = {
-      itemId: collectionId,
-      page: 'page-foreword'
-    };
-  }
-
-  setPageIntroductionAsPrevious(collectionId: string) {
-    this.prevItemTitle = $localize`:@@CollectionIntroduction.Introduction:Inledning`;
-    this.prevItem = {
-      itemId: collectionId,
-      page: 'page-introduction'
-    };
-  }
-
-  async previous(test?: boolean) {
-    if (this.parentPageType === 'page-text') {
-      this.tocService.getTableOfContents(this.collectionId).subscribe(
-        toc => {
-          this.findNext(toc);
-        }
-      );
-    }
-    if (this.prevItem !== undefined && test !== true) {
-      await this.open(this.prevItem);
-    } else if (test && this.prevItem !== undefined) {
-      return true;
-    } else if (test && this.prevItem === undefined) {
-      return false;
-    }
-    return false;
-  }
-
-  async next(test?: boolean) {
-    if (this.tocItemId !== 'mediaCollections' && this.parentPageType === 'page-text') {
-      this.tocService.getTableOfContents(this.collectionId).subscribe(
-        toc => {
-          this.findNext(toc);
-        }
-      );
-    }
-    if (this.nextItem !== undefined && test !== true) {
-      await this.open(this.nextItem);
-    } else if (test && this.nextItem !== undefined) {
-      return true;
-    } else if (test && this.nextItem === undefined) {
-      return false;
-    }
-    return false;
-  }
-
-  findNext(toc: any) {
-    if (this.flattenedToc.length < 1) {
-      this.flatten(toc);
-    }
-    if (this.activeTocOrder === 'alphabetical') {
-      this.sortFlattenedTocAlphabetically();
-    } else if (this.activeTocOrder === 'chronological') {
-      this.sortFlattenedTocChronologically();
-    } else if (this.activeTocOrder === 'categorical') {
-      this.sortFlattenedTocCategorically();
-    }
-    let itemFound = this.setCurrentPreviousAndNextItemsFromFlattenedToc(this.tocItemId);
-    if (!itemFound) {
-      if (this.tocItemId.indexOf(';') > -1) {
-        let searchTocId = this.tocItemId.split(';')[0];
-        // The current toc item was not found with position in legacy id, so look for toc item without position
-        itemFound = this.setCurrentPreviousAndNextItemsFromFlattenedToc(searchTocId);
-        if (!itemFound && this.tocItemId.split(';')[0].split('_').length > 2) {
-          // The current toc item was not found without position either, so look without chapter if any
-          const chapterStartPos = this.tocItemId.split(';')[0].lastIndexOf('_');
-          searchTocId = this.tocItemId.slice(0, chapterStartPos);
-          itemFound = this.setCurrentPreviousAndNextItemsFromFlattenedToc(searchTocId);
-        }
-      }
-    }
-  }
-
-  setCurrentPreviousAndNextItemsFromFlattenedToc(currentTextId: string) {
-    // get the id of the current toc item in the flattened toc array
-    let currentId = 0;
-    let currentItemFound = false;
-    for (let i = 0; i < this.flattenedToc.length; i ++) {
-      if ( this.flattenedToc[i].itemId === currentTextId ) {
-        currentId = i;
-        currentItemFound = true;
-        break;
-      }
-    }
-    let nextId = 0 as any;
-    let prevId = 0 as any;
-    // last item
-    if ((currentId + 1) === this.flattenedToc.length) {
-      // nextId = 0; // this line makes the text-changer into a loop
-      nextId = null;
-    } else {
-      nextId = currentId + 1;
-    }
-
-    if (currentId === 0) {
-      // prevId = this.flattened.length - 1; // this line makes the text-changer into a loop
-      prevId = null;
-    } else {
-      prevId = currentId - 1;
-    }
-
-    // Set the new next, previous and current items only if on page-text in order to prevent these
-    // from flashing before the new page is loaded.
-    if (this.parentPageType === 'page-text') {
-      if (nextId !== null) {
-        this.lastItem = false;
-        this.nextItem = this.flattenedToc[nextId];
-        if (this.nextItem !== undefined && this.nextItem.text !== undefined) {
-          this.nextItemTitle = String(this.nextItem.text);
-        } else {
-          this.nextItemTitle = '';
-        }
-      } else {
-        this.lastItem = true;
-        this.nextItem = null;
-        this.nextItemTitle = '';
-      }
-    }
-
-    if (prevId !== null) {
-      if (this.parentPageType === 'page-text') {
-        this.firstItem = false;
-        this.prevItem = this.flattenedToc[prevId];
-        if (this.prevItem !== undefined && this.prevItem.text !== undefined) {
-          this.prevItemTitle = String(this.prevItem.text);
-        } else {
-          this.prevItemTitle = '';
-        }
-      }
-    } else {
-      if (this.collectionHasIntro) {
-        this.firstItem = false;
-        this.setPageIntroductionAsPrevious(this.collectionId);
-      } else if (this.collectionHasForeword) {
-        this.firstItem = false;
-        this.setPageForewordAsPrevious(this.collectionId);
-      } else if (this.collectionHasTitle) {
-        this.firstItem = false;
-        this.setPageTitleAsPrevious(this.collectionId);
-      } else if (this.collectionHasCover) {
-        this.firstItem = false;
-        this.setPageCoverAsPrevious(this.collectionId);
-      } else {
-        this.firstItem = true;
-        this.prevItem = null;
-        this.prevItemTitle = '';
-      }
-    }
-
-    if (this.parentPageType === 'page-text') {
-      if (this.flattenedToc[currentId] !== undefined) {
-        this.currentItemTitle = String(this.flattenedToc[currentId].text);
-      } else {
-        this.currentItemTitle = '';
-      }
-    }
-    return currentItemFound;
-  }
-
-  flatten(toc: any) {
-    if (toc !== null && toc !== undefined) {
-      if (toc.children) {
-        for (let i = 0, count = toc.children.length; i < count; i++) {
-          if (toc.children[i].itemId !== undefined && toc.children[i].itemId !== '') {
-            this.flattenedToc.push(toc.children[i]);
-          }
-          this.flatten(toc.children[i]);
-        }
-      }
-    }
-  }
-
-  sortFlattenedTocAlphabetically() {
-    if (this.flattenedToc.length > 0) {
-      this.flattenedToc.sort(
-        (a: any, b: any) =>
-          (a.text !== undefined && b.text !== undefined) ?
-            ((String(a.text).toUpperCase() < String(b.text).toUpperCase()) ? -1 :
-            (String(a.text).toUpperCase() > String(b.text).toUpperCase()) ? 1 : 0) : 0
-      );
-    }
-  }
-
-  sortFlattenedTocChronologically() {
-    if (this.flattenedToc.length > 0) {
-      this.flattenedToc.sort(
-        (a: any, b: any) =>
-          (a.date < b.date) ? -1 : (a.date > b.date) ? 1 : 0
-      );
-    }
-  }
-
-  sortFlattenedTocCategorically() {
-    const primarySortKey = config.component?.collectionSideMenu?.categoricalSortingPrimaryKey ?? '';
-    const secondarySortKey = config.component?.collectionSideMenu?.categoricalSortingSecondaryKey ?? '';
-
-    if (this.flattenedToc.length > 0 && primarySortKey && secondarySortKey) {
-      if (primarySortKey === 'date') {
-        sortArrayOfObjectsNumerically(this.flattenedToc, primarySortKey, 'asc');
-      } else {
-        sortArrayOfObjectsAlphabetically(this.flattenedToc, primarySortKey);
-      }
-
-      const categorized: any[] = [];
-      let categoryItems: any[] = [];
-      let prevCategory = '';
-
-      for (let i = 0; i < this.flattenedToc.length; i++) {
-        const currentCategory = this.flattenedToc[i][primarySortKey];
-        if (i < 1) {
-          prevCategory = currentCategory;
-        }
-        if (currentCategory !== prevCategory) {
-          if (secondarySortKey === 'date') {
-            sortArrayOfObjectsNumerically(categoryItems, secondarySortKey, 'asc');
-          } else if (secondarySortKey) {
-            sortArrayOfObjectsAlphabetically(categoryItems, secondarySortKey);
-          }
-          categorized.push(categoryItems);
-          categoryItems = [];
-        }
-        categoryItems.push(this.flattenedToc[i]);
-      }
-
-      if (categoryItems.length > 0) {
-        if (secondarySortKey === 'date') {
-          sortArrayOfObjectsNumerically(categoryItems, secondarySortKey, 'asc');
-        } else if (secondarySortKey) {
-          sortArrayOfObjectsAlphabetically(categoryItems, secondarySortKey);
-        }
-        categorized.push(categoryItems);
-      }
-      this.flattenedToc = categorized.flat();
-    }
-  }
-
-  findPrevTitle(toc: any, currentIndex: any, prevChild?: any) {
-    if (currentIndex === 0) {
-      this.findPrevTitle(prevChild, prevChild.length);
-    }
-    for (let i = currentIndex; i > 0; i--) {
-      if (toc[i - 1] !== undefined) {
-        if (toc[i - 1].type !== 'subtitle' && toc[i - 1].type !== 'section_title') {
-          return toc[i - 1];
-        }
-      }
-    }
-  }
-
-  async open(item: any) {
-    if (item.page !== undefined) {
-      // Open text in page-cover, page-title, page-foreword, page-introduction or media-collection
-      if (item.page === 'page-cover') {
-        this.router.navigate(['/collection', item.itemId, 'cover']);
-      } else if (item.page === 'page-title') {
-        this.router.navigate(['/collection', item.itemId, 'title']);
-      } else if (item.page === 'page-foreword') {
-        this.router.navigate(['/collection', item.itemId, 'foreword']);
-      } else if (item.page === 'page-introduction') {
-        this.router.navigate(['/collection', item.itemId, 'introduction']);
-      } else if (item.page === 'media-collection') {
-        this.router.navigate(['/media-collection']);
-      }
-    } else {
-      // Open text in page-text
-      let itemIdParts = item.itemId.split(';');
-      let positionId = '';
-      if (itemIdParts.length > 1) {
-        positionId = itemIdParts[1];
-      }
-      itemIdParts = itemIdParts[0].split('_');
-      const collectionId = itemIdParts[0];
-      const publicationId = itemIdParts[1];
-      let chapterId = '';
-      if (itemIdParts.length > 2) {
-        chapterId = itemIdParts[2];
-      }
-
-      this.router.navigate(
-        (
-          chapterId ? ['/collection', collectionId, 'text', publicationId, chapterId] :
-          ['/collection', collectionId, 'text', publicationId]
-        ),
-        (positionId ? { queryParams: { position: positionId } } : {})
-      );
-    }
   }
 
 }

--- a/src/app/pages/collection/cover/collection-cover.page.html
+++ b/src/app/pages/collection/cover/collection-cover.page.html
@@ -1,7 +1,7 @@
 <ion-header class="ion-no-border">
   <ion-toolbar class="secondary">
 
-    <text-changer *ngIf="!mobileMode" [textItemID]="collectionID" [parentPageType]="'page-cover'" class="text-changer-desktop-mode"></text-changer>
+    <text-changer *ngIf="!mobileMode" [textItemID]="collectionID" [parentPageType]="'cover'" class="text-changer-desktop-mode"></text-changer>
 
   </ion-toolbar>
 </ion-header>
@@ -18,4 +18,4 @@
   </ng-template>
 </ion-content>
 
-<text-changer *ngIf="mobileMode" [textItemID]="collectionID" [parentPageType]="'page-cover'" class="text-changer-mobile-mode"></text-changer>
+<text-changer *ngIf="mobileMode" [textItemID]="collectionID" [parentPageType]="'cover'" class="text-changer-mobile-mode"></text-changer>

--- a/src/app/pages/collection/foreword/collection-foreword.page.html
+++ b/src/app/pages/collection/foreword/collection-foreword.page.html
@@ -1,7 +1,7 @@
 <ion-header class="ion-no-border">
   <ion-toolbar class="secondary">
 
-    <text-changer slot="start" *ngIf="!mobileMode" [textItemID]="collectionID" [parentPageType]="'page-foreword'" class="text-changer-desktop-mode"></text-changer>
+    <text-changer slot="start" *ngIf="!mobileMode" [textItemID]="collectionID" [parentPageType]="'foreword'" class="text-changer-desktop-mode"></text-changer>
 
     <ion-buttons slot="end" class="secondary-toolbar-buttons-wrapper">
       <ion-button *ngIf="showURNButton" (click)="showReference()">
@@ -35,4 +35,4 @@
   </article>
 </ion-content>
 
-<text-changer *ngIf="mobileMode" [textItemID]="collectionID" [parentPageType]="'page-foreword'" class="text-changer-mobile-mode"></text-changer>
+<text-changer *ngIf="mobileMode" [textItemID]="collectionID" [parentPageType]="'foreword'" class="text-changer-mobile-mode"></text-changer>

--- a/src/app/pages/collection/introduction/collection-introduction.page.html
+++ b/src/app/pages/collection/introduction/collection-introduction.page.html
@@ -1,7 +1,7 @@
 <ion-header class="ion-no-border">
   <ion-toolbar class="secondary">
 
-    <text-changer *ngIf="!mobileMode" [textItemID]="collectionID" [parentPageType]="'page-introduction'" class="text-changer-desktop-mode"></text-changer>
+    <text-changer *ngIf="!mobileMode" [textItemID]="collectionID" [parentPageType]="'introduction'" class="text-changer-desktop-mode"></text-changer>
 
     <ion-buttons slot="end" class="secondary-toolbar-buttons-wrapper">
       <ion-button *ngIf="showTextDownloadButton" (click)="showDownloadModal()">
@@ -98,4 +98,4 @@
 
 </ion-content>
 
-<text-changer *ngIf="mobileMode" [textItemID]="collectionID" [parentPageType]="'page-introduction'" class="text-changer-mobile-mode"></text-changer>
+<text-changer *ngIf="mobileMode" [textItemID]="collectionID" [parentPageType]="'introduction'" class="text-changer-mobile-mode"></text-changer>

--- a/src/app/pages/collection/text/collection-text.page.html
+++ b/src/app/pages/collection/text/collection-text.page.html
@@ -5,7 +5,7 @@
     <text-changer *ngIf="!mobileMode"
           [textItemID]="textItemID"
           [textPosition]="textPosition"
-          [parentPageType]="'page-text'"
+          [parentPageType]="'text'"
           class="text-changer-desktop-mode"
     ></text-changer>
 
@@ -247,7 +247,7 @@
 <text-changer *ngIf="mobileMode"
       [textItemID]="textItemID"
       [textPosition]="textPosition"
-      [parentPageType]="'page-text'"
+      [parentPageType]="'text'"
       class="text-changer-mobile-mode"
 ></text-changer>
 

--- a/src/app/pages/collection/title/collection-title.page.html
+++ b/src/app/pages/collection/title/collection-title.page.html
@@ -1,7 +1,7 @@
 <ion-header class="ion-no-border">
   <ion-toolbar class="secondary">
 
-    <text-changer slot="start" *ngIf="!mobileMode" [textItemID]="collectionID" [parentPageType]="'page-title'" class="text-changer-desktop-mode"></text-changer>
+    <text-changer slot="start" *ngIf="!mobileMode" [textItemID]="collectionID" [parentPageType]="'title'" class="text-changer-desktop-mode"></text-changer>
 
     <ion-buttons slot="end" class="secondary-toolbar-buttons-wrapper">
       <ion-button *ngIf="showURNButton" (click)="showReference()">
@@ -38,4 +38,4 @@
   </article>
 </ion-content>
 
-<text-changer *ngIf="mobileMode" [textItemID]="collectionID" [parentPageType]="'page-title'" class="text-changer-mobile-mode"></text-changer>
+<text-changer *ngIf="mobileMode" [textItemID]="collectionID" [parentPageType]="'title'" class="text-changer-mobile-mode"></text-changer>

--- a/src/app/services/collection-toc.service.ts
+++ b/src/app/services/collection-toc.service.ts
@@ -37,7 +37,7 @@ export class CollectionTableOfContentsService {
   getTableOfContents(id: string): Observable<any> {
     if (this.currentUnorderedToc?.collectionId === id) {
       return of(this.currentUnorderedToc);
-    } else {
+    } else if (id) {
       const locale = this.multilingualToc ? '/' + this.activeLocale : '';
       const endpoint = `${this.apiURL}/toc/${id}${locale}`;
 
@@ -46,23 +46,8 @@ export class CollectionTableOfContentsService {
           return of({});
         })
       );
-    }
-  }
-
-  /* NOT IN USE YET */
-  getFlattenedTableOfContents(id: string): Observable<any> {
-    if (this.currentFlattenedToc?.collectionId === id) {
-      return of(this.currentFlattenedToc);
     } else {
-      return this.getTableOfContents(id).pipe(
-        map((toc: any) => {
-          if (toc?.collectionId === id) {
-            return this.currentFlattenedToc;
-          } else {
-            return {};
-          }
-        })
-      );
+      return of({});
     }
   }
 

--- a/src/app/services/collection-toc.service.ts
+++ b/src/app/services/collection-toc.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, LOCALE_ID } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
-import { BehaviorSubject, catchError, map, Observable, of, tap } from 'rxjs';
+import { BehaviorSubject, catchError, map, Observable, of } from 'rxjs';
 
 import { config } from '@config';
 import { flattenObjectTree, sortArrayOfObjectsAlphabetically, sortArrayOfObjectsNumerically } from '@utility-functions';
@@ -10,13 +10,17 @@ import { flattenObjectTree, sortArrayOfObjectsAlphabetically, sortArrayOfObjects
   providedIn: 'root',
 })
 export class CollectionTableOfContentsService {
-  private activeTocOrder: BehaviorSubject<string> = new BehaviorSubject('default');
+  private activeTocOrder: string = '';
   private apiURL: string = '';
-  private cachedTOC: any = {};
-  private cachedFlattenedTOC: any = {};
-  private currentCollectionTOC$ = new BehaviorSubject<any>(null);
-  private currentFlattenedCollectionTOC$ = new BehaviorSubject<any>(null);
-  private multilingualTOC: boolean = false;
+  private categoricalTocPrimarySortKey: string = 'date';
+  private categoricalTocSecondarySortKey: string = '';
+  private currentUnorderedToc: any = {};          // default order current TOC
+  private currentUnorderedFlattenedToc: any = {}; // default order flattened current TOC
+  private currentToc: any = {};                   // possibly ordered current TOC
+  private currentFlattenedToc: any = {};          // possibly ordered, flattened current TOC
+  private currentToc$ = new BehaviorSubject<any>(null);
+  private currentFlattenedToc$ = new BehaviorSubject<any>(null);
+  private multilingualToc: boolean = false;
 
   constructor(
     private http: HttpClient,
@@ -25,31 +29,19 @@ export class CollectionTableOfContentsService {
     const apiBaseURL = config.app?.backendBaseURL ?? '';
     const projectName = config.app?.projectNameDB ?? '';
     this.apiURL = apiBaseURL + '/' + projectName;
-    this.multilingualTOC = config.app?.i18n?.multilingualCollectionTableOfContents ?? false;
+    this.multilingualToc = config.app?.i18n?.multilingualCollectionTableOfContents ?? false;
+    this.categoricalTocPrimarySortKey = config.component?.collectionSideMenu?.categoricalSortingPrimaryKey ?? 'date';
+    this.categoricalTocSecondarySortKey = config.component?.collectionSideMenu?.categoricalSortingSecondaryKey ?? '';
   }
 
   getTableOfContents(id: string): Observable<any> {
-    if (this.cachedTOC?.collectionId === id) {
-      return of(this.cachedTOC);
+    if (this.currentUnorderedToc?.collectionId === id) {
+      return of(this.currentUnorderedToc);
     } else {
-      const locale = this.multilingualTOC ? '/' + this.activeLocale : '';
+      const locale = this.multilingualToc ? '/' + this.activeLocale : '';
       const endpoint = `${this.apiURL}/toc/${id}${locale}`;
 
       return this.http.get(endpoint).pipe(
-        tap({
-          next: (res: any) => {
-            this.cachedTOC = res;
-            this.cachedFlattenedTOC = {
-              collectionId: res.collectionId,
-              text: res.text,
-              children: flattenObjectTree(res, 'children', 'itemId')
-            };
-          },
-          error: error => {
-            this.cachedTOC = {};
-            this.cachedFlattenedTOC = {};
-          }
-        }),
         catchError((e: any) => {
           return of({});
         })
@@ -57,14 +49,15 @@ export class CollectionTableOfContentsService {
     }
   }
 
+  /* NOT IN USE YET */
   getFlattenedTableOfContents(id: string): Observable<any> {
-    if (this.cachedFlattenedTOC?.collectionId === id) {
-      return of(this.cachedFlattenedTOC);
+    if (this.currentFlattenedToc?.collectionId === id) {
+      return of(this.currentFlattenedToc);
     } else {
       return this.getTableOfContents(id).pipe(
         map((toc: any) => {
           if (toc?.collectionId === id) {
-            return this.cachedFlattenedTOC;
+            return this.currentFlattenedToc;
           } else {
             return {};
           }
@@ -80,37 +73,118 @@ export class CollectionTableOfContentsService {
    * @param language optional
    */
   getFirstItem(collectionID: string, language?: string): Observable<any> {
-    language = language && this.multilingualTOC ? '/' + language : '';
+    language = language && this.multilingualToc ? '/' + language : '';
     const endpoint = `${this.apiURL}/toc-first/${collectionID}${language}`;
     return this.http.get(endpoint);
   }
 
-  setActiveTocOrder(newTocOrder: string) {
-    this.activeTocOrder.next(newTocOrder);
+  /**
+   * Gets the table of contents for a collection, creates an ordered version
+   * of it and emits both flattened and non-flattened versions of it to
+   * subscribers. This function should only be called in app.component when
+   * the collection changes and in the collection side menu whenever the
+   * ordering of the collection TOC changes.
+   */
+  setCurrentCollectionToc(collectionId: string, order: string = 'default') {
+    this.getTableOfContents(collectionId).subscribe((toc: any) => {
+      if (toc?.collectionId && (
+        collectionId !== this.currentToc?.collectionId ||
+        order !== this.activeTocOrder
+      )) {
+        // Change of collection or order of the TOC
+
+        this.activeTocOrder = order;
+
+        // Scenarios:
+        // 1. New collection -> always default order to begin with
+        // 2. Same collection, default order
+        // 3. Same collection, non-default order
+
+        if (collectionId !== this.currentToc?.collectionId) {
+          // 1.
+          // Cache the current default-ordered (!) collection side menu TOC
+          this.currentToc = {
+            ...toc,
+            order: order
+          };
+          this.currentFlattenedToc = {
+            ...this.currentToc,
+            children: flattenObjectTree(toc, 'children', 'itemId')
+          };
+          this.currentUnorderedToc = this.currentToc;
+          this.currentUnorderedFlattenedToc = this.currentFlattenedToc;
+        } else {
+          // The collection has not changed, so we can use the stored TOC
+          if (order === 'default') {
+            // 2.
+            // Restore the default ordered TOC
+            this.currentToc = this.currentUnorderedToc;
+            this.currentFlattenedToc = this.currentUnorderedFlattenedToc;
+          } else {
+            // 3.
+            // Construct ordered TOC
+            let orderedToc = [];
+
+            if (
+              order === 'alphabetical' &&
+              config.component?.collectionSideMenu?.sortableCollectionsAlphabetical?.includes(collectionId)
+            ) {
+              orderedToc = this.constructAlphabeticalMenu(this.currentUnorderedFlattenedToc.children);
+            } else if (
+              order === 'chronological' &&
+              config.component?.collectionSideMenu?.sortableCollectionsChronological?.includes(collectionId)
+            ) {
+              orderedToc = this.constructCategoricalMenu(this.currentUnorderedFlattenedToc.children, 'date');
+            } else if (
+              order === 'categorical' &&
+              config.component?.collectionSideMenu?.sortableCollectionsCategorical?.includes(collectionId)
+            ) {
+              orderedToc = this.constructCategoricalMenu(
+                this.currentUnorderedFlattenedToc.children,
+                this.categoricalTocPrimarySortKey,
+                this.categoricalTocSecondarySortKey
+              )
+            }
+
+            if (orderedToc.length) {
+              // Store original and flattened versions of the ordered TOC
+              this.currentToc = {
+                ...this.currentToc,
+                children: orderedToc,
+                order: order
+              };
+
+              if (order === 'chronological' || order === 'categorical') {
+                orderedToc = flattenObjectTree({children: orderedToc}, 'children', 'itemId');
+              }
+
+              this.currentFlattenedToc = {
+                ...this.currentFlattenedToc,
+                children: orderedToc,
+                order: order
+              };
+            }
+          }
+        }
+      } else {
+        this.currentToc = {};
+        this.currentFlattenedToc = {};
+        this.currentUnorderedToc = {};
+        this.currentUnorderedFlattenedToc = {};
+      }
+
+      // Emit original and flattened versions of the TOC to subscribers
+      this.currentToc$.next(this.currentToc);
+      this.currentFlattenedToc$.next(this.currentFlattenedToc);
+    });
   }
 
-  getActiveTocOrder(): Observable<string> {
-    return this.activeTocOrder.asObservable();
+  getCurrentCollectionToc(): Observable<any> {
+    return this.currentToc$.asObservable();
   }
 
-  setCurrentCollectionTOC(collectionId: string) {
-    if (collectionId) {
-      this.getTableOfContents(collectionId).subscribe((toc: any) => {
-        this.currentCollectionTOC$.next(toc);
-        this.currentFlattenedCollectionTOC$.next(this.cachedFlattenedTOC);
-      });
-    } else {
-      this.currentCollectionTOC$.next({});
-      this.currentFlattenedCollectionTOC$.next([]);
-    }
-  }
-
-  getCurrentCollectionTOC(): Observable<any> {
-    return this.currentCollectionTOC$.asObservable();
-  }
-
-  getCurrentFlattenedCollectionTOC(): Observable<any> {
-    return this.currentFlattenedCollectionTOC$.asObservable();
+  getCurrentFlattenedCollectionToc(): Observable<any> {
+    return this.currentFlattenedToc$.asObservable();
   }
 
   getStaticTableOfContents(id: string): Observable<string> {
@@ -132,7 +206,7 @@ export class CollectionTableOfContentsService {
    * returns a new array where the TOC items have been sorted alphabetically
    * (ascendingly) on the 'text' property of each item.
    */
-  constructAlphabeticalMenu(flattenedMenuData: any[]) {
+  private constructAlphabeticalMenu(flattenedMenuData: any[]) {
     const alphabeticalMenu: any[] = [];
 
     for (const child of flattenedMenuData) {
@@ -149,14 +223,11 @@ export class CollectionTableOfContentsService {
    * Given a flattened collection TOC as the array `flattenedMenuData`,
    * returns a new array where the TOC items have been sorted according
    * to the `primarySortKey` and (optional) `secondarySortKey` properties.
-   * If `returnFlattened` is true, the returned array is flattened, retaining
-   * only items with `itemId` property.
    */
-  constructCategoricalMenu(
+  private constructCategoricalMenu(
     flattenedMenuData: any[],
     primarySortKey: string,
-    secondarySortKey?: string,
-    returnFlattened: boolean = false
+    secondarySortKey?: string
   ) {
     const orderedList: any[] = [];
 
@@ -220,9 +291,7 @@ export class CollectionTableOfContentsService {
       categoricalMenu[0].children = childItems;
     }
 
-    return returnFlattened
-          ? flattenObjectTree({children: categoricalMenu}, 'children', 'itemId')
-          : categoricalMenu;
+    return categoricalMenu;
   }
 
 }


### PR DESCRIPTION
This commit fixes a bug introduced by [a25be18](https://github.com/slsfi/digital-edition-frontend-ng/commit/a25be1899f2e35e3cb8dec398907738bc573427b) leading to the document title not being set on collection pages if opting out of server-side rendering of the collection side menu. Previously the document title was set for collection pages by the collection side menu component, but since it’s not necessarily always loaded by SSR, the functionality has been moved to the text-changer component, which is always loaded. Several improvements to the collection side menu and the text-changer have also been made. For instance, the collection TOC is loaded in a service and utilized by both components, eliminating the need to load the same TOC twice, and the previous/next text buttons in the text-changer are now links.