### PR TITLE
fix: correctly infer app mode on touch devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - Deps: update `ng-extract-i18n-merge` to 2.10.0.
 - Deps: update `@types/node` to 20.11.17.
 
+### Fixed
+
+- Correctly infer app mode on touch devices. Previously the app was set to mobile mode on all touchscreen devices, which was not optimal for e.g. laptops with touchscreens.
+
 
 
 ## [1.2.3] – 2024-01-26

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -19,12 +19,22 @@ import { TopMenuComponent } from '@components/menus/top/top-menu.component';
   ],
   imports: [
     BrowserModule,
-    IonicModule.forRoot(
-      {
-        mode: 'md',
-        backButtonText: '',
+    IonicModule.forRoot({
+      backButtonText: '',
+      mode: 'md',
+      platform: {
+        /**
+         * The default `desktop` function returns false for devices with a touchscreen.
+         * This is not wanted, so test the user agent for 'Mobi' instead, see
+         * - https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent#mobile_tablet_or_desktop
+         * - https://ionicframework.com/docs/angular/platform#customizing-platform-detection-functions
+         */
+        'desktop': (win) => {
+          const isMobile = /Mobi/i.test(win.navigator.userAgent);
+          return !isMobile;
+        }
       }
-    ),
+    }),
     AppRoutingModule,
     CommonModule,
     CollectionSideMenuComponent,

--- a/src/app/services/platform.service.ts
+++ b/src/app/services/platform.service.ts
@@ -22,9 +22,21 @@ export class PlatformService {
     return this.mode === 'desktop';
   }
 
+  /**
+   * The app mode is set to 'desktop' if
+   * a) the user agent string does NOT contain "Mobi" (see app.module.ts),
+   * b) and the device is not a tablet (Ionic defines tablets as iPads,
+   *    Android-devices and any device with viewport roughly between 390
+   *    and 800 px).
+   * In any other case the mode is set to 'mobile'. If the platform can’t
+   * be determined, it’s set to 'desktop'.
+   */
   private detectPlatform() {
     try {
-      if (this.platform.is('desktop')) {
+      if (
+        this.platform.is('desktop') &&
+        !this.platform.is('tablet')
+      ) {
         this.mode = 'desktop';
       } else {
         this.mode = 'mobile';


### PR DESCRIPTION
Previously the app was set to mobile mode on all touchscreen devices, which was not optimal for e.g. laptops with touchscreens.