### PR TITLE
build(deps): remove xliff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - Refactor requests for flattened collection table of contents to use function in the collection TOC service.
 - Refactor the download texts modal to get the current text title from the document head service.
 - Updated the development notes with brief descriptions of dependencies.
-- Deps: update Angular to 17.1.3.
-- Deps: update Ionic to 7.7.1.
+- Deps: update `@angular` to 17.1.3.
+- Deps: update `@ionic` to 7.7.1.
 - Deps: update `marked` to 12.0.0.
 - Deps: update `jasmine-core` to 5.1.2.
 - Deps: update `ng-extract-i18n-merge` to 2.10.0.
@@ -30,6 +30,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Fixed
 
 - Correctly infer app mode on touch devices. Previously the app was set to mobile mode on all touchscreen devices, which was not optimal for e.g. laptops with touchscreens.
+
+### Removed
+
+- Deps: `xliff`.
 
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
         "marked": "^12.0.0",
         "rxjs": "~7.8.1",
         "tslib": "^2.6.2",
-        "xliff": "^6.2.0",
         "zone.js": "~0.14.3"
       },
       "devDependencies": {
@@ -11319,7 +11318,8 @@
     "node_modules/sax": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.3.0.tgz",
-      "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA=="
+      "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==",
+      "dev": true
     },
     "node_modules/schema-utils": {
       "version": "4.0.0",
@@ -13361,25 +13361,6 @@
       "integrity": "sha512-sID0rrVCqkVNUn8t6xuv9+6FViXjUVXq8H5rWOH2rz9fDNQEd4g0EA2XlcEdJXRz5BMEn4O1pJFdT+z4YHhoWw==",
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/xliff": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/xliff/-/xliff-6.2.0.tgz",
-      "integrity": "sha512-vNS61d3ro1+nuyD+7fTNIUpKdRbF7HqHKVaZBFcChNJqNwXw5Y2Xhx6+JdPtnQ8feL0DtGnJWbwoPtrRxqd62w==",
-      "dependencies": {
-        "xml-js": "1.6.11"
-      }
-    },
-    "node_modules/xml-js": {
-      "version": "1.6.11",
-      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
-      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
-      "dependencies": {
-        "sax": "^1.2.4"
-      },
-      "bin": {
-        "xml-js": "bin/cli.js"
       }
     },
     "node_modules/xmldoc": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "marked": "^12.0.0",
     "rxjs": "~7.8.1",
     "tslib": "^2.6.2",
-    "xliff": "^6.2.0",
     "zone.js": "~0.14.3"
   },
   "devDependencies": {


### PR DESCRIPTION
xliff was used by an old script that converted legacy i18n json-files to xliff-format, but the script has been removed a long time ago.