### PR TITLE
refactor: defer loading epub viewer to browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 - Defer loading of the facsimile component on the collection text page to the browser. This increases server-side rendering performance since the component isn’t rendered on the server.
 - Defer loading of the illustrations component on the collection text page to the browser. This increases server-side rendering performance since the component isn’t rendered on the server.
+- Defer loading of the epub viewer component to the browser, since it’s not SSR-compatible. The epub title is shown as a `<h1>` placeholder in the server response. Also show pdf title as `<h1>` in the pdf viewer component.
 - Refactor requests for flattened collection table of contents to use function in the collection TOC service.
 - Refactor the download texts modal to get the current text title from the document head service.
 - Updated the development notes with brief descriptions of dependencies.

--- a/src/app/components/pdf-viewer/pdf-viewer.component.html
+++ b/src/app/components/pdf-viewer/pdf-viewer.component.html
@@ -84,7 +84,6 @@
 </ion-header>
 
 <ion-content class="no-padding" [scrollX]="false" [scrollY]="false">
-  
+  <h1 class="screen-reader-only" [innerHTML]="pdfData.title || ''"></h1>
   <object [data]="pdfURL" type="application/pdf"></object>
-
 </ion-content>

--- a/src/app/pages/ebook/ebook.page.html
+++ b/src/app/pages/ebook/ebook.page.html
@@ -1,19 +1,21 @@
-<epub-viewer *ngIf="(filename && ebookType === 'epub'); else pdf"
-      id="epub-page-container"
-      class="ion-page"
-      [epubFileName]="filename"
-></epub-viewer>
-
-<ng-template #pdf>
-      <pdf-viewer *ngIf="(filename && ebookType === 'pdf'); else invalidFilename"
-            id="pdf-page-container"
-            class="ion-page"
-            [pdfFileName]="filename"
-      ></pdf-viewer>
-</ng-template>
-
-<ng-template #invalidFilename>
-      <ion-content class="ebook-ion-content">
-            <p class="ebook-error-message" i18n="@@Ebook.InvalidFilename">Ogiltigt filnamn. E-boken kunde inte hittas.</p>
-      </ion-content>
-</ng-template>
+@if (filename && ebookType === 'epub') {
+  @defer (on immediate) {
+    <epub-viewer
+          id="epub-page-container"
+          class="ion-page"
+          [epubFileName]="filename"
+    ></epub-viewer>
+  } @placeholder {
+    <h1 class="screen-reader-only" [innerHTML]="title"></h1>
+  }
+} @else if (filename && ebookType === 'pdf') {
+  <pdf-viewer
+        id="pdf-page-container"
+        class="ion-page"
+        [pdfFileName]="filename"
+  ></pdf-viewer>
+} @else {
+  <ion-content class="ebook-ion-content">
+    <p class="ebook-error-message" i18n="@@Ebook.InvalidFilename">Ogiltigt filnamn. E-boken kunde inte hittas.</p>
+  </ion-content>
+}

--- a/src/app/pages/ebook/ebook.page.ts
+++ b/src/app/pages/ebook/ebook.page.ts
@@ -12,6 +12,7 @@ import { config } from '@config';
 export class EbookPage implements OnInit {
   ebookType: string = '';
   filename: string = '';
+  title: string = '';
 
   constructor(
     private route: ActivatedRoute
@@ -23,8 +24,9 @@ export class EbookPage implements OnInit {
       this.ebookType = '';
       const availableEbooks: any[] = config.ebooks ?? [];
       for (const ebook of availableEbooks) {
-        if (ebook.filename === params['filename']) {
-          this.filename = params['filename'];
+        if (ebook.filename === params.filename) {
+          this.filename = ebook.filename;
+          this.title = ebook.title;
           this.ebookType = this.filename.substring(
             this.filename.lastIndexOf('.') + 1, this.filename.length
           ) || '';


### PR DESCRIPTION
Defer loading of the epub viewer component to the browser, since it’s not SSR-compatible. The epub title is shown as a `<h1>` placeholder in the server response. Also show pdf title as `<h1>` in the pdf viewer component.