### PR TITLE
refactor: hide secondary toolbar button labels if viewport max-width …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Changed
 
+- Button labels in the secondary toolbar are hidden when the viewport is less than or equal to 960px wide, the same as for the labels in the top menu.
 - Deps: update `@angular` to 17.2.3.
 - Deps: update `@ionic` to 7.7.3.
 - Deps: update `express` to 4.18.3.

--- a/src/theme/common/secondary-toolbar.scss
+++ b/src/theme/common/secondary-toolbar.scss
@@ -39,7 +39,7 @@ ion-toolbar.secondary {
       .side-title {
         font-size: 0.625rem;
 
-        @media only screen and (max-width: 820px) {
+        @media only screen and (max-width: 960px) {
           clip: rect(1px, 1px, 1px, 1px);
           clip-path: inset(50%);
           height: 1px;


### PR DESCRIPTION
…960px

This aligns the behavior with the button labels in the top menu.