### PR TITLE
refactor: replace browserTarget with buildTarget in extract-i18n options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Changed
 
+- Replace deprecated `browserTarget` with `buildTarget` in `extract-i18n` options in `angular.json`.
 - Update `nginx` to 1.25.4.
 - Deps: update `@angular` to 17.3.2.
 - Deps: update `@ionic` to 7.8.2.

--- a/angular.json
+++ b/angular.json
@@ -137,7 +137,7 @@
         "extract-i18n": {
           "builder": "ng-extract-i18n-merge:ng-extract-i18n-merge",
           "options": {
-            "browserTarget": "app:build",
+            "buildTarget": "app:build",
             "format": "xlf2",
             "outputPath": "src/locale",
             "targetFiles": [


### PR DESCRIPTION
browserTarget has been deprecated.