### PR TITLE
feature: support facsimile-only icon in collection side menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- Support for showing a ”facsimile-only icon” next to items in the collection side menu that have the `facsimileOnly` property set to `true` in the collection table of contents file.
+
 ### Changed
 
 - Change search method on the (named entity) index page from fuzzy to substring search when the provider is ElasticSearch.

--- a/src/app/components/menus/collection-side/collection-side-menu.component.html
+++ b/src/app/components/menus/collection-side/collection-side-menu.component.html
@@ -101,7 +101,15 @@
       {{item.text}}
       <span class="description" *ngIf="item.description">{{item.description}}</span>
     </span>
-    <ion-icon *ngIf="item.children" name="chevron-forward-outline" class="toggle-icon"
+    <ion-icon *ngIf="!item.children && item.facsimileOnly"
+          name="image-outline"
+          class="item-icon-r facs-only-icon"
+          aria-hidden="true"
+    ></ion-icon>
+    <ion-icon *ngIf="item.children"
+          name="chevron-forward-outline"
+          class="item-icon-r toggle-icon"
+          aria-hidden="true"
           [class.open]="selectedMenu.includes(item.itemId) || selectedMenu.includes(item.nodeId)"
     ></ion-icon>
 </ng-template>

--- a/src/app/components/menus/main-side/main-side-menu.component.html
+++ b/src/app/components/menus/main-side/main-side-menu.component.html
@@ -37,7 +37,10 @@
 
 <ng-template #menuItemContent let-item>
     <span class="label">{{item.title}}</span>
-    <ion-icon *ngIf="item.children" name="chevron-forward-outline" class="toggle-icon"
+    <ion-icon *ngIf="item.children"
+          name="chevron-forward-outline"
+          class="item-icon-r toggle-icon"
+          aria-hidden="true"
           [class.open]="selectedMenu.includes(item.nodeId)"
     ></ion-icon>
 </ng-template>

--- a/src/theme/common/side-menu.scss
+++ b/src/theme/common/side-menu.scss
@@ -50,7 +50,7 @@ li {
                 color: var(--side-menu-selected-description-text-color);
             }
 
-            ion-icon.toggle-icon {
+            ion-icon.item-icon-r {
                 color: var(--side-menu-selected-text-color);
             }
         }
@@ -71,16 +71,21 @@ li {
             margin-top: 5px;
         }
 
-        ion-icon.toggle-icon {
-            color: var(--side-menu-text-color);
-            font-size: 1.25rem;
-            flex-shrink: 0;
-            margin: 0 8px 0 auto;
-            transform: rotate(0);
-            transition: transform ease-in-out 0.2s;
+        ion-icon {
+            &.item-icon-r {
+                color: var(--side-menu-text-color);
+                font-size: 1.25rem;
+                flex-shrink: 0;
+                margin: 0 8px 0 auto;
+            }
 
-            &.open {
-                transform: rotate(90deg);
+            &.toggle-icon {
+                transform: rotate(0);
+                transition: transform ease-in-out 0.2s;
+    
+                &.open {
+                    transform: rotate(90deg);
+                }
             }
         }
     }


### PR DESCRIPTION
Add support for showing a ”facsimile-only icon” next to items in the collection side menu that have the `facsimileOnly` property set to `true` in the collection table of contents file.