### PR TITLE
fix(text-changer): match type in collectionId comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- Match type when comparing collection IDs in text-changer component (i.e. allow `collectionId` to be either string or number in table of content JSON-files).
+
 
 
 ## [1.4.3] – 2024-07-22

--- a/src/app/components/text-changer/text-changer.component.ts
+++ b/src/app/components/text-changer/text-changer.component.ts
@@ -83,7 +83,7 @@ export class TextChangerComponent implements OnChanges, OnDestroy, OnInit {
       (toc: any) => {
         if (
           toc?.children?.length &&
-          this.collectionId === toc?.collectionId
+          this.collectionId === String(toc?.collectionId)
         ) {
           this.collectionTitle = toc.text || '';
           // Prepend the frontmatter pages to the TOC array


### PR DESCRIPTION
Match type when comparing collection IDs in text-changer component (i.e. allow `collectionId` to be either string or number in table of content JSON-files).