### PR TITLE
refactor(home-page): reduce landscape banner height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Changed
+
+- Home page: reduce landscape banner image height to 40% on viewport widths less than 1100px.
+
 
 
 ## [1.4.4] – 2024-08-08

--- a/src/app/pages/home/home.page.scss
+++ b/src/app/pages/home/home.page.scss
@@ -22,6 +22,11 @@ ion-content.portrait-mode::part(scroll) {
 	padding: 0;
 	position: relative;
 
+	// Reduce banner height on narrow screens in landscape mode
+	@media screen and (max-width: 1100px) {
+		height: 40%;
+	}
+
 	.landscape-background-image {
 		background-position: 50% 50%;
 		background-repeat: no-repeat;


### PR DESCRIPTION
The landscape banner image height is reduced to 40% on viewport widths less than 1100px.