### PR TITLE
fix: correctly set document title on revisiting collection pages in nav stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Fixed
 
 - Media collections: reduce filter select widths to prevent clear button from wrapping to a new line when all three filter categories are available.
+- Document title set correctly when going back to previous collection pages in nav stack.
 
 
 

--- a/src/app/components/menus/main-side/main-side-menu.component.ts
+++ b/src/app/components/menus/main-side/main-side-menu.component.ts
@@ -328,7 +328,7 @@ export class MainSideMenuComponent implements OnInit, OnChanges {
           this.headService.setTitle([String(item.title), $localize`:@@MainSideMenu.MediaCollections:Bildbank`]);
         } else if (!this.topMenuItems.includes(item.parentPath) && this.urlSegments[0]?.path !== 'collection') {
           // For top menu items the title is set by app.component, and
-          // for collections the title is set by the collection side menu
+          // for collections the title is set by the text-changer component
           this.headService.setTitle([String(item.title)]);
         }
         return item;

--- a/src/app/components/text-changer/text-changer.component.ts
+++ b/src/app/components/text-changer/text-changer.component.ts
@@ -28,6 +28,11 @@ import { PlatformService } from '@services/platform.service';
 })
 export class TextChangerComponent implements OnChanges, OnDestroy, OnInit {
   @Input() parentPageType: string = 'text';
+  // ionViewActive is true when the parent page component is active in the DOM,
+  // i.e. the component has entered the Ionic life cycle hook ionViewWillEnter.
+  // Set to false when the parent component has entered ionViewWillLeave life
+  // cycle hook. This way we can react to ActivatedRoute changes only in active
+  // components.
   @Input() ionViewActive: boolean = true;
 
   activeMenuOrder: string = '';
@@ -50,7 +55,8 @@ export class TextChangerComponent implements OnChanges, OnDestroy, OnInit {
   ) {}
 
   ngOnChanges(changes: SimpleChanges) {
-    if (changes.ionViewActive.currentValue && !changes.ionViewActive.firstChange) {
+    if (changes.ionViewActive?.currentValue && !changes.ionViewActive?.firstChange) {
+      // Update current text when the ionic view becomes active again
       this.updateCurrentText();
     }
   }
@@ -63,7 +69,7 @@ export class TextChangerComponent implements OnChanges, OnDestroy, OnInit {
     // Then observe changes to route parameters, and act on changes to either.
     this.tocSubscr = this.tocService.getCurrentFlattenedCollectionToc().pipe(
       switchMap((toc: any) => {
-        // Early return if no TOC
+        // Early return if the view is not active or no TOC
         if (!this.ionViewActive || !toc || !toc?.children?.length) {
           return [];
         }
@@ -94,14 +100,6 @@ export class TextChangerComponent implements OnChanges, OnDestroy, OnInit {
       if (!collectionID || collectionID !== String(toc?.collectionId)) {
         return;
       }
-
-      /*
-      console.log('ToC:', toc);
-      console.log('collectionID:', collectionID);
-      console.log('publicationID:', publicationID);
-      console.log('chapterID:', chapterID);
-      console.log('position:', position);
-      */
 
       this.textItemID =
             (publicationID && chapterID) ? collectionID + '_' + publicationID + '_' + chapterID
@@ -156,7 +154,6 @@ export class TextChangerComponent implements OnChanges, OnDestroy, OnInit {
    * text, the parent text title is set as the document title.
    */
   private updateCurrentText() {
-    console.log('Updating current text in toc: ', this.tocItemId);
     const foundTextIndex = this.getCurrentTextIndex();
     if (foundTextIndex > -1) {
       this.currentTocTextIndex = foundTextIndex;

--- a/src/app/components/text-changer/text-changer.component.ts
+++ b/src/app/components/text-changer/text-changer.component.ts
@@ -1,8 +1,8 @@
 import { Component, Input, OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
 import { NgIf } from '@angular/common';
-import { RouterLink } from '@angular/router';
+import { ActivatedRoute, RouterLink } from '@angular/router';
 import { IonicModule } from '@ionic/angular';
-import { Subscription } from 'rxjs';
+import { combineLatest, distinctUntilChanged, map, Subscription, switchMap } from 'rxjs';
 
 import { config } from '@config';
 import { CollectionTableOfContentsService } from '@services/collection-toc.service';
@@ -27,127 +27,136 @@ import { PlatformService } from '@services/platform.service';
   imports: [NgIf, RouterLink, IonicModule, CollectionPagePathPipe, CollectionPagePositionQueryparamPipe]
 })
 export class TextChangerComponent implements OnChanges, OnDestroy, OnInit {
-  @Input() parentPageType: string = '';
-  @Input() textItemID: string = '';
-  @Input() textPosition: string = '';
+  @Input() parentPageType: string = 'text';
+  @Input() ionViewActive: boolean = true;
 
+  activeMenuOrder: string = '';
   collectionId: string = '';
   collectionTitle: string = '';
   currentTocTextIndex: number = 0;
   flattenedToc: any[] = [];
   frontMatterPages: any[] = [];
   mobileMode: boolean = false;
+  textItemID: string = '';
+  textPosition: string = '';
   tocItemId: string = '';
   tocSubscr: Subscription | null = null;
 
   constructor(
     private headService: DocumentHeadService,
     private platformService: PlatformService,
+    private route: ActivatedRoute,
     private tocService: CollectionTableOfContentsService
   ) {}
 
   ngOnChanges(changes: SimpleChanges) {
-    let firstChange = true;
-    for (const propName in changes) {
-      if (changes.hasOwnProperty(propName)) {
-        if (propName === 'textItemID') {
-          if (!changes.textItemID.firstChange) {
-            firstChange = false;
-          }
-        } else if (propName === 'textPosition') {
-          if (!changes.textPosition.firstChange) {
-            firstChange = false;
-          }
-        } else if (propName === 'parentPageType') {
-          if (!changes.parentPageType.firstChange) {
-            firstChange = false;
-          }
-        }
-      }
-    }
-
-    if (!firstChange) {
-      this.updateVariables();
+    if (changes.ionViewActive.currentValue && !changes.ionViewActive.firstChange) {
       this.updateCurrentText();
     }
   }
 
   ngOnInit() {
     this.mobileMode = this.platformService.isMobile();
-    this.updateVariables();
-    this.setFrontmatterPagesArray();
 
-    // Subscribe to BehaviorSubject emitting the current (flattened) TOC.
-    // The received TOC is already properly ordered.
-    this.tocSubscr = this.tocService.getCurrentFlattenedCollectionToc().subscribe(
-      (toc: any) => {
-        if (
-          toc?.children?.length &&
-          this.collectionId === String(toc?.collectionId)
-        ) {
-          this.collectionTitle = toc.text || '';
-          // Prepend the frontmatter pages to the TOC array
-          this.flattenedToc = this.frontMatterPages.concat(toc.children);
-          // Search for the current text in the array and display it
-          this.updateCurrentText();
+    // Subscribe to BehaviorSubject emitting the current (flattened) TOC
+    // as outer observable (the received TOC is already properly ordered).
+    // Then observe changes to route parameters, and act on changes to either.
+    this.tocSubscr = this.tocService.getCurrentFlattenedCollectionToc().pipe(
+      switchMap((toc: any) => {
+        // Early return if no TOC
+        if (!this.ionViewActive || !toc || !toc?.children?.length) {
+          return [];
         }
+        // Now that we have the TOC, we switch to observing route parameters
+        return combineLatest([
+          this.route.paramMap,
+          this.route.queryParamMap
+        ]).pipe(
+          map(([paramMap, queryParamMap]) => {
+            const collectionID = paramMap.get('collectionID');
+            const publicationID = paramMap.get('publicationID');
+            const chapterID = paramMap.get('chapterID');
+            const position = queryParamMap.get('position');
+            return { toc, collectionID, publicationID, chapterID, position };
+          }),
+          distinctUntilChanged((prev, curr) => 
+            prev.toc?.collectionId === curr.toc?.collectionId &&
+            prev.toc?.order === curr.toc?.order &&
+            prev.collectionID === curr.collectionID &&
+            prev.publicationID === curr.publicationID &&
+            prev.chapterID === curr.chapterID &&
+            prev.position === curr.position
+          )
+        );
+      })
+    ).subscribe(({ toc, collectionID, publicationID, chapterID, position }) => {
+      // Check that collectionID not nullish and matches id in TOC to proceed
+      if (!collectionID || collectionID !== String(toc?.collectionId)) {
+        return;
       }
-    );
+
+      /*
+      console.log('ToC:', toc);
+      console.log('collectionID:', collectionID);
+      console.log('publicationID:', publicationID);
+      console.log('chapterID:', chapterID);
+      console.log('position:', position);
+      */
+
+      this.textItemID =
+            (publicationID && chapterID) ? collectionID + '_' + publicationID + '_' + chapterID
+            : publicationID ? collectionID + '_' + publicationID
+            : collectionID;
+      this.tocItemId = position ? this.textItemID + ';' + position : this.textItemID;
+      this.textPosition = position || '';
+
+      if (this.collectionId !== collectionID || this.activeMenuOrder !== toc?.order) {
+        // A new TOC or changed ordering of current TOC:
+        // concatenate front matter pages and TOC to form flattened TOC
+        this.collectionId = collectionID;
+        this.collectionTitle = toc.text || '';
+        this.activeMenuOrder = toc?.order || 'default';
+        this.flattenedToc = this.getFrontmatterPages(collectionID).concat(toc.children);
+      }
+
+      this.updateCurrentText();
+    });
   }
 
   ngOnDestroy() {
     this.tocSubscr?.unsubscribe();
   }
 
-  private updateVariables() {
-    if (!this.parentPageType) {
-      this.parentPageType = 'text';
-    }
+  private getFrontmatterPages(collectionId: string) {
+    type FrontMatterKey = 'cover' | 'title' | 'foreword' | 'introduction';
+    const frontMatterKeys: FrontMatterKey[] = ['cover', 'title', 'foreword', 'introduction'];
+    const localizedTexts: Record<FrontMatterKey, string> = {
+      cover: $localize`:@@CollectionCover.Cover:Omslag`,
+      title: $localize`:@@CollectionTitle.TitlePage:Titelblad`,
+      foreword: $localize`:@@CollectionForeword.Foreword:Förord`,
+      introduction: $localize`:@@CollectionIntroduction.Introduction:Inledning`
+    };
 
-    this.collectionId = this.textItemID.split('_')[0];
-    this.tocItemId = this.textPosition
-          ? this.textItemID + ';' + this.textPosition
-          : this.textItemID;
-  }
-
-  private setFrontmatterPagesArray() {
-    if (config.collections?.frontMatterPages?.cover) {
-      this.frontMatterPages.push({
-        text: $localize`:@@CollectionCover.Cover:Omslag`,
-        page: 'cover',
-        itemId: this.collectionId
-      });
-    }
-    if (config.collections?.frontMatterPages?.title) {
-      this.frontMatterPages.push({
-        text: $localize`:@@CollectionTitle.TitlePage:Titelblad`,
-        page: 'title',
-        itemId: this.collectionId
-      });
-    }
-    if (config.collections?.frontMatterPages?.foreword) {
-      this.frontMatterPages.push({
-        text: $localize`:@@CollectionForeword.Foreword:Förord`,
-        page: 'foreword',
-        itemId: this.collectionId
-      });
-    }
-    if (config.collections?.frontMatterPages?.introduction) {
-      this.frontMatterPages.push({
-        text: $localize`:@@CollectionIntroduction.Introduction:Inledning`,
-        page: 'introduction',
-        itemId: this.collectionId
-      });
-    }
+    return frontMatterKeys.reduce<{ text: string; page: string; itemId: string }[]>((pages, key) => {
+      if (config.collections?.frontMatterPages?.[key]) {
+        pages.push({
+          text: localizedTexts[key],
+          page: key,
+          itemId: collectionId
+        });
+      }
+      return pages;
+    }, []);
   }
 
   /**
    * Updates the text that's displayed as the current text (as well as the
    * previous and next text), and sets the document title to the current
    * text title. If the current text is a positioned heading in a longer
-   * text, the patent text title is set as the document title.
+   * text, the parent text title is set as the document title.
    */
   private updateCurrentText() {
+    console.log('Updating current text in toc: ', this.tocItemId);
     const foundTextIndex = this.getCurrentTextIndex();
     if (foundTextIndex > -1) {
       this.currentTocTextIndex = foundTextIndex;
@@ -159,33 +168,23 @@ export class TextChangerComponent implements OnChanges, OnDestroy, OnInit {
     // Set the document title to the current text title.
     // Positioned item's title should not be set, instead we have to
     // search for the non-positioned item's title.
-    let titleItemIndex = this.currentTocTextIndex;
-    if (this.textPosition) {
-      titleItemIndex = this.flattenedToc.findIndex(
-        ({ itemId }) => itemId === this.textItemID
-      );
-    }
+    const titleItemIndex = this.textPosition
+          ? this.flattenedToc.findIndex(({ itemId }) => itemId === this.textItemID)
+          : this.currentTocTextIndex;
 
     const itemTitle = titleItemIndex > -1
           ? this.flattenedToc[titleItemIndex].text || ''
           : this.flattenedToc[this.currentTocTextIndex].text || '';
+
     this.headService.setTitle([itemTitle, this.collectionTitle]);
   }
 
   private getCurrentTextIndex() {
-    let currentTextIndex = -1;
-    for (let i = 0; i < this.flattenedToc.length; i++) {
-      if (!this.flattenedToc[i].page) {
-        // Text page
-        if (this.flattenedToc[i].itemId === this.tocItemId) {
-          return i;
-        }
-      } else if (this.flattenedToc[i].page === this.parentPageType) {
-        // Front matter page
-        return i;
+    return this.flattenedToc.findIndex(item => {
+      if (!item.page && item.itemId === this.tocItemId) {
+        return true;
       }
-    }
-    return currentTextIndex;
+      return item.page === this.parentPageType;
+    });
   }
-
 }

--- a/src/app/pages/collection/cover/collection-cover.page.html
+++ b/src/app/pages/collection/cover/collection-cover.page.html
@@ -1,7 +1,7 @@
 <ion-header class="ion-no-border">
   <ion-toolbar class="secondary">
 
-    <text-changer *ngIf="!mobileMode" [textItemID]="collectionID" [parentPageType]="'cover'" class="text-changer-desktop-mode"></text-changer>
+    <text-changer *ngIf="!mobileMode" [parentPageType]="'cover'" class="text-changer-desktop-mode"></text-changer>
 
   </ion-toolbar>
 </ion-header>
@@ -18,4 +18,4 @@
   </ng-template>
 </ion-content>
 
-<text-changer *ngIf="mobileMode" [textItemID]="collectionID" [parentPageType]="'cover'" class="text-changer-mobile-mode"></text-changer>
+<text-changer *ngIf="mobileMode" [parentPageType]="'cover'" class="text-changer-mobile-mode"></text-changer>

--- a/src/app/pages/collection/cover/collection-cover.page.html
+++ b/src/app/pages/collection/cover/collection-cover.page.html
@@ -1,7 +1,11 @@
 <ion-header class="ion-no-border">
   <ion-toolbar class="secondary">
 
-    <text-changer *ngIf="!mobileMode" [parentPageType]="'cover'" class="text-changer-desktop-mode"></text-changer>
+    <text-changer *ngIf="!mobileMode"
+          [parentPageType]="'cover'"
+          [ionViewActive]="_activeComponent"
+          class="text-changer-desktop-mode"
+    ></text-changer>
 
   </ion-toolbar>
 </ion-header>
@@ -18,4 +22,8 @@
   </ng-template>
 </ion-content>
 
-<text-changer *ngIf="mobileMode" [parentPageType]="'cover'" class="text-changer-mobile-mode"></text-changer>
+<text-changer *ngIf="mobileMode"
+      [parentPageType]="'cover'"
+      [ionViewActive]="_activeComponent"
+      class="text-changer-mobile-mode"
+></text-changer>

--- a/src/app/pages/collection/cover/collection-cover.page.ts
+++ b/src/app/pages/collection/cover/collection-cover.page.ts
@@ -12,6 +12,7 @@ import { PlatformService } from '@services/platform.service';
   styleUrls: ['./collection-cover.page.scss']
 })
 export class CollectionCoverPage implements OnInit {
+  _activeComponent: boolean = true;
   collectionID: string = '';
   coverData$: Observable<any>;
   mobileMode: boolean = false;
@@ -36,6 +37,14 @@ export class CollectionCoverPage implements OnInit {
         );
       })
     );
+  }
+
+  ionViewWillEnter() {
+    this._activeComponent = true;
+  }
+
+  ionViewWillLeave() {
+    this._activeComponent = false;
   }
 
   private getCoverDataFromMdContent(fileID: string): Observable<any> {

--- a/src/app/pages/collection/foreword/collection-foreword.page.html
+++ b/src/app/pages/collection/foreword/collection-foreword.page.html
@@ -1,7 +1,11 @@
 <ion-header class="ion-no-border">
   <ion-toolbar class="secondary">
 
-    <text-changer slot="start" *ngIf="!mobileMode" [parentPageType]="'foreword'" class="text-changer-desktop-mode"></text-changer>
+    <text-changer slot="start" *ngIf="!mobileMode"
+          [parentPageType]="'foreword'"
+          [ionViewActive]="_activeComponent"
+          class="text-changer-desktop-mode"
+    ></text-changer>
 
     <ion-buttons slot="end" class="secondary-toolbar-buttons-wrapper">
       <ion-button *ngIf="showURNButton" (click)="showReference()">
@@ -35,4 +39,8 @@
   </article>
 </ion-content>
 
-<text-changer *ngIf="mobileMode" [parentPageType]="'foreword'" class="text-changer-mobile-mode"></text-changer>
+<text-changer *ngIf="mobileMode"
+      [parentPageType]="'foreword'"
+      [ionViewActive]="_activeComponent"
+      class="text-changer-mobile-mode"
+></text-changer>

--- a/src/app/pages/collection/foreword/collection-foreword.page.html
+++ b/src/app/pages/collection/foreword/collection-foreword.page.html
@@ -1,7 +1,7 @@
 <ion-header class="ion-no-border">
   <ion-toolbar class="secondary">
 
-    <text-changer slot="start" *ngIf="!mobileMode" [textItemID]="collectionID" [parentPageType]="'foreword'" class="text-changer-desktop-mode"></text-changer>
+    <text-changer slot="start" *ngIf="!mobileMode" [parentPageType]="'foreword'" class="text-changer-desktop-mode"></text-changer>
 
     <ion-buttons slot="end" class="secondary-toolbar-buttons-wrapper">
       <ion-button *ngIf="showURNButton" (click)="showReference()">
@@ -35,4 +35,4 @@
   </article>
 </ion-content>
 
-<text-changer *ngIf="mobileMode" [textItemID]="collectionID" [parentPageType]="'foreword'" class="text-changer-mobile-mode"></text-changer>
+<text-changer *ngIf="mobileMode" [parentPageType]="'foreword'" class="text-changer-mobile-mode"></text-changer>

--- a/src/app/pages/collection/foreword/collection-foreword.page.ts
+++ b/src/app/pages/collection/foreword/collection-foreword.page.ts
@@ -20,6 +20,7 @@ import { ViewOptionsService } from '@services/view-options.service';
   styleUrls: ['./collection-foreword.page.scss']
 })
 export class CollectionForewordPage implements OnDestroy, OnInit {
+  _activeComponent: boolean = true;
   collectionID: string = '';
   intervalTimerId: number = 0;
   mobileMode: boolean = false;
@@ -80,6 +81,14 @@ export class CollectionForewordPage implements OnDestroy, OnInit {
 
   ngOnDestroy() {
     this.textsizeSubscription?.unsubscribe();
+  }
+
+  ionViewWillEnter() {
+    this._activeComponent = true;
+  }
+
+  ionViewWillLeave() {
+    this._activeComponent = false;
   }
 
   private loadForeword(id: string, lang: string): Observable<string> {

--- a/src/app/pages/collection/introduction/collection-introduction.page.html
+++ b/src/app/pages/collection/introduction/collection-introduction.page.html
@@ -1,7 +1,7 @@
 <ion-header class="ion-no-border">
   <ion-toolbar class="secondary">
 
-    <text-changer *ngIf="!mobileMode" [textItemID]="collectionID" [parentPageType]="'introduction'" class="text-changer-desktop-mode"></text-changer>
+    <text-changer *ngIf="!mobileMode" [parentPageType]="'introduction'" class="text-changer-desktop-mode"></text-changer>
 
     <ion-buttons slot="end" class="secondary-toolbar-buttons-wrapper">
       <ion-button *ngIf="showTextDownloadButton" (click)="showDownloadModal()">
@@ -98,4 +98,4 @@
 
 </ion-content>
 
-<text-changer *ngIf="mobileMode" [textItemID]="collectionID" [parentPageType]="'introduction'" class="text-changer-mobile-mode"></text-changer>
+<text-changer *ngIf="mobileMode" [parentPageType]="'introduction'" class="text-changer-mobile-mode"></text-changer>

--- a/src/app/pages/collection/introduction/collection-introduction.page.html
+++ b/src/app/pages/collection/introduction/collection-introduction.page.html
@@ -1,7 +1,11 @@
 <ion-header class="ion-no-border">
   <ion-toolbar class="secondary">
 
-    <text-changer *ngIf="!mobileMode" [parentPageType]="'introduction'" class="text-changer-desktop-mode"></text-changer>
+    <text-changer slot="start" *ngIf="!mobileMode"
+          [parentPageType]="'introduction'"
+          [ionViewActive]="_activeComponent"
+          class="text-changer-desktop-mode"
+    ></text-changer>
 
     <ion-buttons slot="end" class="secondary-toolbar-buttons-wrapper">
       <ion-button *ngIf="showTextDownloadButton" (click)="showDownloadModal()">
@@ -98,4 +102,8 @@
 
 </ion-content>
 
-<text-changer *ngIf="mobileMode" [parentPageType]="'introduction'" class="text-changer-mobile-mode"></text-changer>
+<text-changer *ngIf="mobileMode"
+      [parentPageType]="'introduction'"
+      [ionViewActive]="_activeComponent"
+      class="text-changer-mobile-mode"
+></text-changer>

--- a/src/app/pages/collection/introduction/collection-introduction.page.ts
+++ b/src/app/pages/collection/introduction/collection-introduction.page.ts
@@ -26,6 +26,7 @@ import { isBrowser } from '@utility-functions';
   styleUrls: ['./collection-introduction.page.scss']
 })
 export class CollectionIntroductionPage implements OnInit, OnDestroy {
+  _activeComponent: boolean = true;
   collectionID: string = '';
   collectionLegacyId: string = '';
   hasSeparateIntroToc: boolean = false;
@@ -181,6 +182,14 @@ export class CollectionIntroductionPage implements OnInit, OnDestroy {
     this.unlistenMouseoverEvents?.();
     this.unlistenMouseoutEvents?.();
     this.unlistenFirstTouchStartEvent?.();
+  }
+
+  ionViewWillEnter() {
+    this._activeComponent = true;
+  }
+
+  ionViewWillLeave() {
+    this._activeComponent = false;
   }
 
   private loadIntroduction(id: string, lang: string) {

--- a/src/app/pages/collection/text/collection-text.page.html
+++ b/src/app/pages/collection/text/collection-text.page.html
@@ -2,7 +2,7 @@
   <ion-toolbar class="secondary">
 
     <!-- Text changer in desktop mode -->
-    <text-changer *ngIf="!mobileMode"
+    <text-changer slot="start" *ngIf="!mobileMode"
           [parentPageType]="'text'"
           [ionViewActive]="_activeComponent"
           class="text-changer-desktop-mode"

--- a/src/app/pages/collection/text/collection-text.page.html
+++ b/src/app/pages/collection/text/collection-text.page.html
@@ -3,9 +3,8 @@
 
     <!-- Text changer in desktop mode -->
     <text-changer *ngIf="!mobileMode"
-          [textItemID]="textItemID"
-          [textPosition]="textPosition"
           [parentPageType]="'text'"
+          [ionViewActive]="_activeComponent"
           class="text-changer-desktop-mode"
     ></text-changer>
 
@@ -245,9 +244,8 @@
 
 <!-- Text changer in mobile mode -->
 <text-changer *ngIf="mobileMode"
-      [textItemID]="textItemID"
-      [textPosition]="textPosition"
       [parentPageType]="'text'"
+      [ionViewActive]="_activeComponent"
       class="text-changer-mobile-mode"
 ></text-changer>
 

--- a/src/app/pages/collection/text/collection-text.page.ts
+++ b/src/app/pages/collection/text/collection-text.page.ts
@@ -31,6 +31,7 @@ export class CollectionTextPage implements OnDestroy, OnInit {
   @ViewChildren('fabColumnOptions') fabColumnOptions: QueryList<IonFabList>;
   @ViewChildren('fabColumnOptionsButton') fabColumnOptionsButton: QueryList<IonFabButton>;
 
+  _activeComponent: boolean = true;
   activeMobileModeViewIndex: number = 0;
   addViewPopoverisOpen: boolean = false;
   collectionAndPublicationLegacyId: string = '';
@@ -233,6 +234,14 @@ export class CollectionTextPage implements OnDestroy, OnInit {
     this.unlistenMouseoverEvents?.();
     this.unlistenMouseoutEvents?.();
     this.unlistenFirstTouchStartEvent?.();
+  }
+
+  ionViewWillEnter() {
+    this._activeComponent = true;
+  }
+
+  ionViewWillLeave() {
+    this._activeComponent = false;
   }
 
   private setViews() {

--- a/src/app/pages/collection/title/collection-title.page.html
+++ b/src/app/pages/collection/title/collection-title.page.html
@@ -1,7 +1,7 @@
 <ion-header class="ion-no-border">
   <ion-toolbar class="secondary">
 
-    <text-changer slot="start" *ngIf="!mobileMode" [textItemID]="collectionID" [parentPageType]="'title'" class="text-changer-desktop-mode"></text-changer>
+    <text-changer slot="start" *ngIf="!mobileMode" [parentPageType]="'title'" class="text-changer-desktop-mode"></text-changer>
 
     <ion-buttons slot="end" class="secondary-toolbar-buttons-wrapper">
       <ion-button *ngIf="showURNButton" (click)="showReference()">
@@ -38,4 +38,4 @@
   </article>
 </ion-content>
 
-<text-changer *ngIf="mobileMode" [textItemID]="collectionID" [parentPageType]="'title'" class="text-changer-mobile-mode"></text-changer>
+<text-changer *ngIf="mobileMode" [parentPageType]="'title'" class="text-changer-mobile-mode"></text-changer>

--- a/src/app/pages/collection/title/collection-title.page.html
+++ b/src/app/pages/collection/title/collection-title.page.html
@@ -1,7 +1,11 @@
 <ion-header class="ion-no-border">
   <ion-toolbar class="secondary">
 
-    <text-changer slot="start" *ngIf="!mobileMode" [parentPageType]="'title'" class="text-changer-desktop-mode"></text-changer>
+    <text-changer slot="start" *ngIf="!mobileMode"
+          [parentPageType]="'title'"
+          [ionViewActive]="_activeComponent"
+          class="text-changer-desktop-mode"
+    ></text-changer>
 
     <ion-buttons slot="end" class="secondary-toolbar-buttons-wrapper">
       <ion-button *ngIf="showURNButton" (click)="showReference()">
@@ -38,4 +42,8 @@
   </article>
 </ion-content>
 
-<text-changer *ngIf="mobileMode" [parentPageType]="'title'" class="text-changer-mobile-mode"></text-changer>
+<text-changer *ngIf="mobileMode"
+      [parentPageType]="'title'"
+      [ionViewActive]="_activeComponent"
+      class="text-changer-mobile-mode"
+></text-changer>

--- a/src/app/pages/collection/title/collection-title.page.ts
+++ b/src/app/pages/collection/title/collection-title.page.ts
@@ -21,6 +21,7 @@ import { ViewOptionsService } from '@services/view-options.service';
   styleUrls: ['./collection-title.page.scss'],
 })
 export class CollectionTitlePage implements OnDestroy, OnInit {
+  _activeComponent: boolean = true;
   collectionID: string = '';
   intervalTimerId: number = 0;
   loadContentFromMarkdown: boolean = false;
@@ -84,6 +85,14 @@ export class CollectionTitlePage implements OnDestroy, OnInit {
 
   ngOnDestroy() {
     this.textsizeSubscription?.unsubscribe();
+  }
+
+  ionViewWillEnter() {
+    this._activeComponent = true;
+  }
+
+  ionViewWillLeave() {
+    this._activeComponent = false;
   }
 
   private loadTitle(id: string, lang: string): Observable<string | null> {

--- a/src/app/services/document-head.service.ts
+++ b/src/app/services/document-head.service.ts
@@ -48,18 +48,24 @@ export class DocumentHeadService implements OnDestroy {
       }
     }
 
-    if (this.openGraphTags?.enabled) {
-      const ogTitle = compositePageTitle
-        ? compositePageTitle
-        : $localize`:@@Site.Title:Webbplatsens titel`;
-      this.setMetaTag('property', 'og:title', ogTitle.replaceAll(' - ', ' – '));
-    }
-
-    compositePageTitle = compositePageTitle
+    // Construct the final title for the document head
+    const headTitle = compositePageTitle
       ? compositePageTitle + ' - ' + $localize`:@@Site.Title:Webbplatsens titel`
       : $localize`:@@Site.Title:Webbplatsens titel`;
 
-    this.title.setTitle(compositePageTitle);
+    // Set the document title only if it has changed
+    if (this.title.getTitle() !== headTitle) {
+      this.title.setTitle(headTitle);
+
+      // If Open Graph tags are enabled, set the title in the meta tags too.
+      // (hyphens are replaced by dashes)
+      if (this.openGraphTags?.enabled) {
+        const ogTitle = compositePageTitle
+          ? compositePageTitle
+          : $localize`:@@Site.Title:Webbplatsens titel`;
+        this.setMetaTag('property', 'og:title', ogTitle.replaceAll(' - ', ' – '));
+      }
+    }
   }
 
   setLinks(routerURL: string) {


### PR DESCRIPTION
Prior to this fix the document title was not set correctly when going back to a collection page that had already been visited. This was because in Ionic, the components are not destroyed when leaving views, but saved in a nav stack. The fix uses the Ionic life cycle hooks ionViewWillEnter and ionViewWillLeave on the collection pages to keep track of if the component is active or not, and this information is passed to the text-changer component which sets the document title.

The text-changer component has been refactored to get the information about the current page from the router instead of from input variables.

The document head service has been optimized to avoid unnecessary DOM updates by setting the document title only if it changes.