### PR TITLE
fix(prebuild-generate-static-collection-menus): skip excluded collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- Generate static collection menus prebuild script: skip collections that are not included according to the config.
+
 
 
 ## [1.5.0] – 2024-08-28

--- a/prebuild-generate-static-collection-menus.js
+++ b/prebuild-generate-static-collection-menus.js
@@ -67,15 +67,18 @@ async function generateStaticCollectionMenus() {
       if (multilingualCollectionTOC) {
         collectionsEndpoint += '/' + locale;
       }
+
       const collections = await common.fetchFromAPI(collectionsEndpoint);
+      const includedCollections = config.collections.order.flat();
+
       if (collections) {
         // Loop through all collections
         for (let i = 0; i < collections.length; i++) {
           const collectionId = collections[i]['id'] || 0;
           const collectionTitle = collections[i]['title'] || '';
 
-          if (!collectionId) {
-            break;
+          if (!collectionId || !includedCollections.includes(collectionId)) {
+            continue;
           }
 
           // Get collection TOC
@@ -83,10 +86,11 @@ async function generateStaticCollectionMenus() {
           if (multilingualCollectionTOC) {
             tocEndpoint += '/' + locale;
           }
+          
           const tocJSON = await common.fetchFromAPI(tocEndpoint);
 
           if (tocJSON == null) {
-            console.log('Unable to fetch TOC for collection ', collectionId);
+            console.log('Error: unable to fetch TOC for collection ', collectionId);
             break;
           }
 


### PR DESCRIPTION
Generate static collection menus prebuild script: skip collections that are not included according to the config.