### PR TITLE
fix(prebuild-generate-sitemap): skip excluded collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Fixed
 
 - Generate static collection menus prebuild script: skip collections that are not included according to the config.
+- Generate sitemap prebuild script: skip collections that are not included according to the config.
 
 
 


### PR DESCRIPTION
Generate sitemap prebuild script: skip collections that are not included according to the config.