### PR TITLE
feature: custom frontmatter page names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Added
 
-- Config option `config.component.mainSideMenu.defaultExpanded` to expand the main menu items with children by default, when set to `true`. Defaults to `false`.
+- Config option `config.component.mainSideMenu.defaultExpanded` to expand the main menu items with children by default when set to `true`. Defaults to `false`.
+- Support for custom names for the collection frontmatter pages (cover, title, foreword and introduction). By default, all collections have the same names for the frontmatter pages, set in the translation files in `src/locale/`. The names of these pages can now be set differently for each collection in the JSON table of contents (ToC) files of the collections. The root object in the JSON ToC-files can optionally take the keys `coverPageName`, `titlePageName`, `forewordPageName` and `introductionPageName`. If any of these are set (i.e. have truthy values), those page names are used instead of the default ones. Example of a JSON ToC-file where the introduction page of a particular collection has a non-default name:
+
+```json
+/* 225.json */
+{
+  "text": "About Wittgenstein",
+  "collectionId": "225",
+  "type": "title",
+  "introductionPageName": "G.H. von Wright as a Gateway to Wittgenstein",
+  "children": [
+    /*...*/
+  ]
+}
+```
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,15 +14,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - Support for custom names for the collection frontmatter pages (cover, title, foreword and introduction). By default, all collections have the same names for the frontmatter pages, set in the translation files in `src/locale/`. The names of these pages can now be set differently for each collection in the JSON table of contents (ToC) files of the collections. The root object in the JSON ToC-files can optionally take the keys `coverPageName`, `titlePageName`, `forewordPageName` and `introductionPageName`. If any of these are set (i.e. have truthy values), those page names are used instead of the default ones. Example of a JSON ToC-file where the introduction page of a particular collection has a non-default name:
 
 ```json
-/* 225.json */
 {
   "text": "About Wittgenstein",
   "collectionId": "225",
   "type": "title",
   "introductionPageName": "G.H. von Wright as a Gateway to Wittgenstein",
-  "children": [
-    /*...*/
-  ]
+  "children": []
 }
 ```
 

--- a/src/app/components/menus/collection-side/collection-side-menu.component.html
+++ b/src/app/components/menus/collection-side/collection-side-menu.component.html
@@ -50,28 +50,28 @@
     @if (enableCover) {
       <li [attr.aria-current]="routeUrlSegments[2].path === 'cover' ? 'page' : null" role="menuitem" data-id="toc_cover">
         <a routerLink="{{collectionID | collectionPagePath: 'cover'}}" [class.menu-highlight]="routeUrlSegments[2].path === 'cover'">
-          <span class="label" i18n="@@CollectionCover.Cover">Omslag</span>
+          <span class="label">{{ coverPageName }}</span>
         </a>
       </li>
     }
     @if (enableTitle) {
       <li [attr.aria-current]="routeUrlSegments[2].path === 'title' ? 'page' : null" role="menuitem" data-id="toc_title">
         <a routerLink="{{collectionID | collectionPagePath: 'title'}}" [class.menu-highlight]="routeUrlSegments[2].path === 'title'">
-          <span class="label" i18n="@@CollectionTitle.TitlePage">Titelblad</span>
+          <span class="label">{{ titlePageName }}</span>
         </a>
       </li>
     }
     @if (enableForeword) {
       <li [attr.aria-current]="routeUrlSegments[2].path === 'foreword' ? 'page' : null" role="menuitem" data-id="toc_foreword">
         <a routerLink="{{collectionID | collectionPagePath: 'foreword'}}" [class.menu-highlight]="routeUrlSegments[2].path === 'foreword'">
-          <span class="label" i18n="@@CollectionForeword.Foreword">Förord</span>
+          <span class="label">{{ forewordPageName }}</span>
         </a>
       </li>
     }
     @if (enableIntroduction) {
       <li [attr.aria-current]="routeUrlSegments[2].path === 'introduction' ? 'page' : null" role="menuitem" data-id="toc_introduction">
         <a routerLink="{{collectionID | collectionPagePath: 'introduction'}}" [class.menu-highlight]="routeUrlSegments[2].path === 'introduction'">
-          <span class="label" i18n="@@CollectionIntroduction.Introduction">Inledning</span>
+          <span class="label">{{ introductionPageName }}</span>
         </a>
       </li>
     }

--- a/src/app/components/menus/collection-side/collection-side-menu.component.ts
+++ b/src/app/components/menus/collection-side/collection-side-menu.component.ts
@@ -27,15 +27,19 @@ export class CollectionSideMenuComponent implements OnInit, OnChanges, OnDestroy
   activeMenuOrder: string = '';
   collectionMenu: any[] = [];
   collectionTitle: string = '';
+  coverPageName: string = '';
   currentMenuItemId: string = '';
   enableCover: boolean = false;
   enableTitle: boolean = false;
   enableForeword: boolean = false;
   enableIntroduction: boolean = false;
+  forewordPageName: string = '';
+  introductionPageName: string = '';
   isLoading: boolean = true;
   selectedMenu: string[] = []; // list of all open menu items in the menu tree
   sortOptions: string[] = [];
   sortSelectOptions: Record<string, any> = {};
+  titlePageName: string = '';
   tocSubscr: Subscription | null = null;
 
   constructor(
@@ -105,13 +109,19 @@ export class CollectionSideMenuComponent implements OnInit, OnChanges, OnDestroy
         const scrollTimeout = this.activeMenuOrder !== toc?.order ? 1000 : 700;
         this.activeMenuOrder = toc?.order || 'default';
 
+        this.collectionTitle = toc.text || '';
+        this.coverPageName = toc.coverPageName || $localize`:@@CollectionCover.Cover:Omslag`;
+        this.titlePageName = toc.titlePageName || $localize`:@@CollectionTitle.TitlePage:Titelblad`;
+        this.forewordPageName = toc.forewordPageName || $localize`:@@CollectionForeword.Foreword:Förord`;
+        this.introductionPageName = toc.introductionPageName || $localize`:@@CollectionIntroduction.Introduction:Inledning`;
+
         if (toc?.children?.length) {
           this.recursiveInitializeSelectedMenu(toc.children);
-          this.collectionTitle = toc.text || '';
           this.collectionMenu = toc.children;
-          this.isLoading = false;
-          this.updateHighlightedMenuItem(scrollTimeout);
         }
+
+        this.isLoading = false;
+        this.updateHighlightedMenuItem(scrollTimeout);
 
         this.sortOptions = this.setSortOptions(this.collectionID);
       }

--- a/src/app/components/text-changer/text-changer.component.ts
+++ b/src/app/components/text-changer/text-changer.component.ts
@@ -113,7 +113,7 @@ export class TextChangerComponent implements OnChanges, OnDestroy, OnInit {
         this.collectionId = collectionID;
         this.collectionTitle = toc.text || '';
         this.activeMenuOrder = toc?.order || 'default';
-        this.flattenedToc = this.getFrontmatterPages(collectionID).concat(toc.children);
+        this.flattenedToc = this.getFrontmatterPages(collectionID, toc).concat(toc.children);
       }
 
       this.updateCurrentText();
@@ -124,14 +124,14 @@ export class TextChangerComponent implements OnChanges, OnDestroy, OnInit {
     this.tocSubscr?.unsubscribe();
   }
 
-  private getFrontmatterPages(collectionId: string) {
+  private getFrontmatterPages(collectionId: string, toc: any) {
     type FrontMatterKey = 'cover' | 'title' | 'foreword' | 'introduction';
     const frontMatterKeys: FrontMatterKey[] = ['cover', 'title', 'foreword', 'introduction'];
     const localizedTexts: Record<FrontMatterKey, string> = {
-      cover: $localize`:@@CollectionCover.Cover:Omslag`,
-      title: $localize`:@@CollectionTitle.TitlePage:Titelblad`,
-      foreword: $localize`:@@CollectionForeword.Foreword:Förord`,
-      introduction: $localize`:@@CollectionIntroduction.Introduction:Inledning`
+      cover: toc.coverPageName || $localize`:@@CollectionCover.Cover:Omslag`,
+      title: toc.titlePageName || $localize`:@@CollectionTitle.TitlePage:Titelblad`,
+      foreword: toc.forewordPageName || $localize`:@@CollectionForeword.Foreword:Förord`,
+      introduction: toc.introductionPageName || $localize`:@@CollectionIntroduction.Introduction:Inledning`
     };
 
     return frontMatterKeys.reduce<{ text: string; page: string; itemId: string }[]>((pages, key) => {


### PR DESCRIPTION
Adds support for custom names for the collection frontmatter pages (cover, title, foreword and introduction). By default, all collections have the same names for the frontmatter pages, set in the translation files in `src/locale/`. The names of these pages can now be set differently for each collection in the JSON table of contents (ToC) files of the collections. The root object in the JSON ToC-files can optionally take the keys `coverPageName`, `titlePageName`, `forewordPageName` and `introductionPageName`. If any of these are set (i.e. have truthy values), those page names are used instead of the default ones. Example of a JSON ToC-file where the introduction page of a particular collection has a non-default name:

```json
{
  "text": "About Wittgenstein",
  "collectionId": "225",
  "type": "title",
  "introductionPageName": "G.H. von Wright as a Gateway to Wittgenstein",
  "children": []
}
```