### PR TITLE
fix: preserve selected facsimile collection on text change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Fixed
 
 - Clear search field on home page after query, so that when navigating back to the home page, the search field is empty.
+- Preserve selected facsimile collection on text change.
 
 ### Changed
 

--- a/src/app/components/collection-text-types/facsimiles/facsimiles.component.ts
+++ b/src/app/components/collection-text-types/facsimiles/facsimiles.component.ts
@@ -22,11 +22,13 @@ import { sortArrayOfObjectsNumerically } from '@utility-functions';
 export class FacsimilesComponent implements OnInit {
   @Input() facsID: number | undefined = undefined;
   @Input() imageNr: number | undefined = undefined;
+  @Input() sortOrder: number | undefined = undefined;
   @Input() textItemID: string = '';
   @Output() selectedFacsID = new EventEmitter<number>();
   @Output() selectedFacsName = new EventEmitter<string>();
   @Output() selectedImageNr = new EventEmitter<number | null>();
-  
+  @Output() selectedFacsSortOrder = new EventEmitter<number | null>();
+
   angle: number = 0;
   externalFacsimiles: any[] = [];
   facsURLAlternate: string = '';
@@ -113,11 +115,12 @@ export class FacsimilesComponent implements OnInit {
         const inputFacsimile = this.facsimiles.filter((item: any) => {
           return (item.facsimile_id === this.facsID);
         })[0];
-        if (inputFacsimile) {
-          this.selectedFacsimile = inputFacsimile;
-        } else {
-          this.selectedFacsimile = this.facsimiles[0];
-        }
+        this.selectedFacsimile = inputFacsimile ? inputFacsimile : this.facsimiles[0];
+      } else if (this.sortOrder) {
+        const inputFacsimile = this.facsimiles.filter((item: any) => {
+          return (item.priority === this.sortOrder);
+        })[0];
+        this.selectedFacsimile = inputFacsimile ? inputFacsimile : this.facsimiles[0];
       } else if (
         this.externalFacsimiles.length > 0 && 
         (
@@ -145,6 +148,7 @@ export class FacsimilesComponent implements OnInit {
       this.selectedFacsimileIsExternal = true;
       this.emitSelectedFacsimileId(0);
       this.emitSelectedFacsimileName($localize`:@@Facsimiles.ExternalFacsimiles:Externa faksimil`);
+      this.emitSelectedFacsimileSortOrder(null);
       this.emitImageNumber(null);
     } else if (facs) {
       this.initializeDisplayedFacsimile(facs);
@@ -162,11 +166,8 @@ export class FacsimilesComponent implements OnInit {
       ? facs.content?.replace(/src="images\//g, 'src="assets/images/')
       : facs.content;
 
-    if (extImageNr !== undefined) {
-      this.facsNumber = extImageNr;
-    } else {
-      this.facsNumber = facs.page;
-    }
+    this.facsNumber = (extImageNr !== undefined) ? extImageNr : facs.page;
+
     this.facsNumber < 1 ? this.facsNumber = 1 : (
       this.facsNumber > this.numberOfImages ? this.facsNumber = this.numberOfImages : this.facsNumber
     );
@@ -174,6 +175,12 @@ export class FacsimilesComponent implements OnInit {
     if (this.facsimiles.length > 1 || this.externalFacsimiles.length > 0) {
       this.emitSelectedFacsimileId(facs.facsimile_id);
       this.emitSelectedFacsimileName(facs.title);
+    }
+
+    if (this.externalFacsimiles.length < 1 && this.facsimiles.length > 1) {
+      this.emitSelectedFacsimileSortOrder(facs.priority);
+    } else {
+      this.emitSelectedFacsimileSortOrder(null);
     }
 
     if (this.numberOfImages > 1) {
@@ -255,6 +262,10 @@ export class FacsimilesComponent implements OnInit {
       (this.facsimiles.length == 1 && this.externalFacsimiles.length > 0)) {
       this.selectedFacsName.emit(name);
     }
+  }
+
+  emitSelectedFacsimileSortOrder(sortOrder: number | null) {
+    this.selectedFacsSortOrder.emit(sortOrder);
   }
 
   emitImageNumber(nr: number | null) {

--- a/src/app/components/collection-text-types/variants/variants.component.ts
+++ b/src/app/components/collection-text-types/variants/variants.component.ts
@@ -74,11 +74,7 @@ export class VariantsComponent implements OnInit {
       const inputVariant = this.variants.filter((item: any) => {
         return (item.id === this.varID);
       })[0];
-      if (inputVariant) {
-        this.selectedVariant = inputVariant;
-      } else {
-        this.selectedVariant = this.variants[0];
-      }
+      this.selectedVariant = inputVariant ? inputVariant : this.variants[0];
     } else if (this.sortOrder) {
       const inputVariant = this.variants.filter((item: any) => {
         return (item.sort_order === this.sortOrder);

--- a/src/app/pages/collection/text/collection-text.page.html
+++ b/src/app/pages/collection/text/collection-text.page.html
@@ -344,9 +344,11 @@
             [textItemID]="textItemID"
             [facsID]="view.id"
             [imageNr]="view.nr"
+            [sortOrder]="view.sortOrder"
             (selectedFacsID)="updateViewProperty('id', $event, i)"
             (selectedImageNr)="updateViewProperty('nr', $event, i)"
             (selectedFacsName)="updateViewProperty('title', $event, i, false)"
+            (selectedFacsSortOrder)="updateViewProperty('sortOrder', $event, i)"
       ></facsimiles>
     } @loading (minimum 1s) {
       <ion-spinner class="loading" name="crescent"></ion-spinner>

--- a/src/app/pages/collection/text/collection-text.page.ts
+++ b/src/app/pages/collection/text/collection-text.page.ts
@@ -190,8 +190,11 @@ export class CollectionTextPage implements OnDestroy, OnInit {
         parsedViews.forEach((viewObj: any) => {
           const cachedViewObj: any = { type: viewObj.type };
           if (
-            viewObj.type === 'variants' &&
-            viewObj.sortOrder
+            viewObj.sortOrder &&
+            (
+              viewObj.type === 'variants' ||
+              viewObj.type === 'facsimiles'
+            )
           ) {
             cachedViewObj.sortOrder = viewObj.sortOrder;
           }


### PR DESCRIPTION
When navigating from one collection text to another and you have a facsimile view open, a facsimile from the selected facsimile collection is opened if applicable to the new text. The preservation is performed based on the priority/sortOrder of the facsimiles linked to the text. So if a text has two linked facsimiles, with priorities 1 and 2, each opened in a view, and the user navigates to the next text, the facsimile views are loaded with facsimiles with priorities 1 and 2, if the new text has such facsimiles.