### PR TITLE
fix: parsing of `itemId` to router links when position but no chapter…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 - Clear search field on home page after query, so that when navigating back to the home page, the search field is empty.
 - Preserve selected facsimile collection on text change.
+- Parsing of `itemId` to router links when position but no chapter segment is present.
 
 ### Changed
 

--- a/src/app/pipes/collection-page-path.pipe.ts
+++ b/src/app/pipes/collection-page-path.pipe.ts
@@ -22,12 +22,11 @@ export class CollectionPagePathPipe implements PipeTransform {
             case 'introduction':
                 return `/collection/${itemId}/introduction`;
             default:
-                const idList = itemId.split('_');
+                const idList = itemId.split(';')[0].split('_');
                 if (idList.length > 1) {
                     let url = `/collection/${idList[0]}/text/${idList[1]}`;
                     if (idList.length > 2) {
-                        const chapter = idList[2].split(';')[0];
-                        url += `/${chapter}`;
+                        url += `/${idList[2]}`;
                     }
                     return url;
                 } else {


### PR DESCRIPTION
… segment is present