### PR TITLE
feature: variation type view option for variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 }
 ```
 
-- Config option `config.page.text.variantViewOptions` to allow the user to control the type of variation that is displayed in variant texts. It has two properties: `showVariationTypeOption`, which is a boolean used to control if the view option should be shown or not (defaults to `false`), and `defaultVariationType`, which is a string used to control the variation type that is show by default. Possible values include `all` (default) for displaying all variation types, `sub` for displaying only substantial/significant variation, and `none` for hiding all variation highlighting. Example:
+- Config option `config.page.text.variantViewOptions` to allow the user to control the type of variation that is displayed in variant texts. It has two properties: `showVariationTypeOption`, which is a boolean used to control if the view option should be shown or not (defaults to `false`), and `defaultVariationType`, which is a string used to set the variation type that is shown by default. Possible values include `all` (default) for displaying all variation types, `sub` for displaying only substantial/significant variation, and `none` for hiding all variation highlighting. Example:
 
 ```typescript
 export const config: Config = {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 }
 ```
 
-- Config option `config.page.text.variantViewOptions` to allow the user to control the type of variation that is displayed in variant texts.
+- Config option `config.page.text.variantViewOptions` to allow the user to control the type of variation that is displayed in variant texts. It has two properties: `showVariationTypeOption`, which is a boolean used to control if the view option should be shown or not (defaults to `false`), and `defaultVariationType`, which is a string used to control the variation type that is show by default. Possible values include `all` (default) for displaying all variation types, `sub` for displaying only substantial/significant variation, and `none` for hiding all variation highlighting. Example:
+
+```typescript
+export const config: Config = {
+  /*...*/
+  page: {
+    /*...*/
+    text: {
+      /*...*/
+      variantViewOptions: {
+        showVariationTypeOption: true,
+        defaultVariationType: "sub"
+      },
+      /*...*/
+    },
+    /*...*/
+  },
+  /*...*/
+}
+```
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 }
 ```
 
+- Config option `config.page.text.variantViewOptions` to allow the user to control the type of variation that is displayed in variant texts.
+
 ### Fixed
 
 - Clear search field on home page after query, so that when navigating back to the home page, the search field is empty.

--- a/src/app/components/collection-text-types/variants/variants.component.html
+++ b/src/app/components/collection-text-types/variants/variants.component.html
@@ -32,5 +32,8 @@
 
 <div class="tei teiContainer teiVariant"
       [class.show_pageBreakOriginal]="viewOptionsService.show.pageBreakOriginal"
+      [class.show-variations-all]="viewOptionsService.selectedVariationType === 'all'"
+      [class.show-variations-sub]="viewOptionsService.selectedVariationType === 'sub'"
+      [class.show-variations-none]="viewOptionsService.selectedVariationType === 'none'"
       [innerHTML]="text | trustHtml"
 ></div>

--- a/src/app/dialogs/popovers/view-options/view-options.popover.html
+++ b/src/app/dialogs/popovers/view-options/view-options.popover.html
@@ -106,3 +106,22 @@
     }
   </ion-list>
 }
+
+@if (showVariationTypeOption) {
+  <ion-list lines="full">
+    <ion-list-header>
+      <ion-label i18n="@@ViewOptions.VariantOptions">Visningsalternativ, varianter</ion-label>
+    </ion-list-header>
+    <ion-item>
+      <ion-radio-group
+            class="selected-variation-type"
+            [value]="viewOptionsService.selectedVariationType"
+            (ionChange)="setSelectedVariationType($event)"
+      >
+        <ion-radio value="all" labelPlacement="end" justify="start">Visa alla skillnader</ion-radio>
+        <ion-radio value="sub" labelPlacement="end" justify="start">Visa substantiella skillnader</ion-radio>
+        <ion-radio value="none" labelPlacement="end" justify="start">Visa inga skillnader</ion-radio>
+      </ion-radio-group>
+    </ion-item>
+  </ion-list>
+}

--- a/src/app/dialogs/popovers/view-options/view-options.popover.html
+++ b/src/app/dialogs/popovers/view-options/view-options.popover.html
@@ -118,9 +118,9 @@
             [value]="viewOptionsService.selectedVariationType"
             (ionChange)="setSelectedVariationType($event)"
       >
-        <ion-radio value="all" labelPlacement="end" justify="start">Visa alla skillnader</ion-radio>
-        <ion-radio value="sub" labelPlacement="end" justify="start">Visa substantiella skillnader</ion-radio>
-        <ion-radio value="none" labelPlacement="end" justify="start">Visa inga skillnader</ion-radio>
+        <ion-radio value="all" labelPlacement="end" justify="start" i18n="@@ViewOptions.ShowAllVariation">Visa alla skillnader</ion-radio>
+        <ion-radio value="sub" labelPlacement="end" justify="start" i18n="@@ViewOptions.ShowSubstantialVariation">Visa substantiella skillnader</ion-radio>
+        <ion-radio value="none" labelPlacement="end" justify="start" i18n="@@ViewOptions.ShowNoVariation">Visa inga skillnader</ion-radio>
       </ion-radio-group>
     </ion-item>
   </ion-list>

--- a/src/app/dialogs/popovers/view-options/view-options.popover.scss
+++ b/src/app/dialogs/popovers/view-options/view-options.popover.scss
@@ -83,6 +83,10 @@ ion-button.text-xlarge {
 	font-size: 1.75rem !important;
 }
 
+.selected-variation-type {
+	padding: 0.5rem 0;
+}
+
 .asterisk {
 	height: 0.8125rem;
 	padding-right: 0.125rem;

--- a/src/app/dialogs/popovers/view-options/view-options.popover.ts
+++ b/src/app/dialogs/popovers/view-options/view-options.popover.ts
@@ -31,6 +31,7 @@ export class ViewOptionsPopover implements OnDestroy, OnInit {
     pageBreakOriginal: false,
     pageBreakEdition: false
   };
+  showVariationTypeOption: boolean = false;
   textsize: Textsize = Textsize.Small;
   textsizeSubscription: Subscription | null = null;
   togglesCounter: number;
@@ -39,9 +40,10 @@ export class ViewOptionsPopover implements OnDestroy, OnInit {
 
   constructor(
     private popoverCtrl: PopoverController,
-    private viewOptionsService: ViewOptionsService
+    protected viewOptionsService: ViewOptionsService
   ) {
     this.availableToggles = config.page?.text?.viewOptions ?? undefined;
+    this.showVariationTypeOption = config.page?.text?.variantViewOptions?.showVariationTypeOption ?? false;
   }
 
   ngOnInit() {
@@ -64,6 +66,13 @@ export class ViewOptionsPopover implements OnDestroy, OnInit {
       if (value && this.availableToggles[key]) {
         this.checkedToggles++;
       }
+    }
+
+    // The collection text page is the only page where variant view options
+    // should be possibly shown, here we are assuming it's the only page that
+    // does not define the input toggles.
+    if (this.toggles !== undefined && this.showVariationTypeOption) {
+      this.showVariationTypeOption = false;
     }
 
     this.textsizeSubscription = this.viewOptionsService.getTextsize().subscribe(
@@ -149,6 +158,12 @@ export class ViewOptionsPopover implements OnDestroy, OnInit {
 
   setTextSize(size: Textsize) {
     this.viewOptionsService.setTextsize(size);
+  }
+
+  setSelectedVariationType(event: any) {
+    if (event?.detail?.value) {
+      this.viewOptionsService.selectedVariationType = event.detail.value;
+    }
   }
 
 }

--- a/src/app/pages/collection/text/collection-text.page.ts
+++ b/src/app/pages/collection/text/collection-text.page.ts
@@ -664,8 +664,17 @@ export class CollectionTextPage implements OnDestroy, OnInit {
 
         eventTarget = this.getEventTarget(event);
         if (
-          eventTarget.classList.contains('variantScrollTarget') ||
-          eventTarget.classList.contains('anchorScrollTarget')
+          (
+            eventTarget.classList.contains('variantScrollTarget') ||
+            eventTarget.classList.contains('anchorScrollTarget')
+          ) &&
+          (
+            this.viewOptionsService.selectedVariationType === 'all' ||
+            (
+              this.viewOptionsService.selectedVariationType === 'sub' &&
+              eventTarget.classList.contains('substantial')
+            )
+          )
         ) {
           // Click on variant lemma --> highlight and scroll all variant columns
           // in desktop mode; display variant info in infoOverlay in mobile mode.
@@ -1048,7 +1057,10 @@ export class CollectionTextPage implements OnDestroy, OnInit {
               this.ngZone.run(() => {
                 this.showTooltipFromInlineHtml(eventTarget);
               });
-            } else if (eventTarget['classList'].contains('ttVariant')) {
+            } else if (
+              eventTarget['classList'].contains('ttVariant') &&
+              this.viewOptionsService.selectedVariationType !== 'none'
+            ) {
               this.ngZone.run(() => {
                 this.showVariantTooltip(eventTarget);
               });
@@ -1187,6 +1199,12 @@ export class CollectionTextPage implements OnDestroy, OnInit {
   }
 
   private showVariantTooltip(targetElem: HTMLElement) {
+    if (
+      this.viewOptionsService.selectedVariationType === 'sub' &&
+      !targetElem.classList.contains('substantial')
+    ) {
+      return;
+    }
     if (
       targetElem.nextElementSibling?.classList.contains('tooltip') &&
       targetElem.nextElementSibling?.textContent

--- a/src/app/pages/collection/text/collection-text.page.ts
+++ b/src/app/pages/collection/text/collection-text.page.ts
@@ -672,7 +672,10 @@ export class CollectionTextPage implements OnDestroy, OnInit {
             this.viewOptionsService.selectedVariationType === 'all' ||
             (
               this.viewOptionsService.selectedVariationType === 'sub' &&
-              eventTarget.classList.contains('substantial')
+              (
+                eventTarget.classList.contains('substantial') ||
+                eventTarget.classList.contains('lemma')
+              )
             )
           )
         ) {

--- a/src/app/services/view-options.service.ts
+++ b/src/app/services/view-options.service.ts
@@ -21,6 +21,7 @@ export class ViewOptionsService {
     pageBreakOriginal: false,
     pageBreakEdition: false
   };
+  selectedVariationType: string = 'all';
 
   private epubAlertDismissed: boolean = false;
   private textsizeSubject$: BehaviorSubject<Textsize> = new BehaviorSubject<Textsize>(Textsize.Small);
@@ -32,6 +33,7 @@ export class ViewOptionsService {
         this.show[key] = true;
       }
     });
+    this.selectedVariationType = config.page?.text?.variantViewOptions?.defaultVariationType ?? 'all';
   }
 
   getTextsize(): Observable<Textsize> {

--- a/src/assets/config/config.ts
+++ b/src/assets/config/config.ts
@@ -288,6 +288,10 @@ export const config: Config = {
         pageBreakOriginal: true,
         pageBreakEdition: true
       },
+      variantViewOptions: {
+        showVariationTypeOption: false,
+        defaultVariationType: "all"
+      },
       viewTypes: {
         showAll: true,
         readingtext: true,

--- a/src/locale/messages.en.xlf
+++ b/src/locale/messages.en.xlf
@@ -1782,6 +1782,24 @@
         <target>Settings</target>
       </segment>
     </unit>
+    <unit id="ViewOptions.ShowAllVariation">
+      <segment state="initial">
+        <source>Visa alla skillnader</source>
+        <target>Show all variation</target>
+      </segment>
+    </unit>
+    <unit id="ViewOptions.ShowNoVariation">
+      <segment state="initial">
+        <source>Visa inga skillnader</source>
+        <target>Hide variation</target>
+      </segment>
+    </unit>
+    <unit id="ViewOptions.ShowSubstantialVariation">
+      <segment state="initial">
+        <source>Visa substantiella skillnader</source>
+        <target>Show significant variation</target>
+      </segment>
+    </unit>
     <unit id="ViewOptions.Textsize">
       <segment state="initial">
         <source>Textstorlek</source>
@@ -1822,6 +1840,12 @@
       <segment state="initial">
         <source>Välj alla</source>
         <target>Toggle all</target>
+      </segment>
+    </unit>
+    <unit id="ViewOptions.VariantOptions">
+      <segment state="initial">
+        <source>Visningsalternativ, varianter</source>
+        <target>Variant view options</target>
       </segment>
     </unit>
     <unit id="ViewOptions.WorkInfo">

--- a/src/locale/messages.fi.xlf
+++ b/src/locale/messages.fi.xlf
@@ -1782,6 +1782,24 @@
         <target>Asetukset</target>
       </segment>
     </unit>
+    <unit id="ViewOptions.ShowAllVariation">
+      <segment state="initial">
+        <source>Visa alla skillnader</source>
+        <target>Näytä kaikki muutokset</target>
+      </segment>
+    </unit>
+    <unit id="ViewOptions.ShowNoVariation">
+      <segment state="initial">
+        <source>Visa inga skillnader</source>
+        <target>Älä näytä muutoksia</target>
+      </segment>
+    </unit>
+    <unit id="ViewOptions.ShowSubstantialVariation">
+      <segment state="initial">
+        <source>Visa substantiella skillnader</source>
+        <target>Näytä asiamuutokset</target>
+      </segment>
+    </unit>
     <unit id="ViewOptions.Textsize">
       <segment state="initial">
         <source>Textstorlek</source>
@@ -1822,6 +1840,12 @@
       <segment state="initial">
         <source>Välj alla</source>
         <target>Valitse kaikki</target>
+      </segment>
+    </unit>
+    <unit id="ViewOptions.VariantOptions">
+      <segment state="initial">
+        <source>Visningsalternativ, varianter</source>
+        <target>Varianttien näkymävaihtoehdot</target>
       </segment>
     </unit>
     <unit id="ViewOptions.WorkInfo">

--- a/src/locale/messages.sv.xlf
+++ b/src/locale/messages.sv.xlf
@@ -1782,6 +1782,24 @@
         <target>Inställningar</target>
       </segment>
     </unit>
+    <unit id="ViewOptions.ShowAllVariation">
+      <segment state="initial">
+        <source>Visa alla skillnader</source>
+        <target>Visa alla skillnader</target>
+      </segment>
+    </unit>
+    <unit id="ViewOptions.ShowNoVariation">
+      <segment state="initial">
+        <source>Visa inga skillnader</source>
+        <target>Visa inga skillnader</target>
+      </segment>
+    </unit>
+    <unit id="ViewOptions.ShowSubstantialVariation">
+      <segment state="initial">
+        <source>Visa substantiella skillnader</source>
+        <target>Visa substantiella skillnader</target>
+      </segment>
+    </unit>
     <unit id="ViewOptions.Textsize">
       <segment state="initial">
         <source>Textstorlek</source>
@@ -1822,6 +1840,12 @@
       <segment state="initial">
         <source>Välj alla</source>
         <target>Välj alla</target>
+      </segment>
+    </unit>
+    <unit id="ViewOptions.VariantOptions">
+      <segment state="initial">
+        <source>Visningsalternativ, varianter</source>
+        <target>Visningsalternativ, varianter</target>
       </segment>
     </unit>
     <unit id="ViewOptions.WorkInfo">

--- a/src/locale/messages.xlf
+++ b/src/locale/messages.xlf
@@ -1486,6 +1486,21 @@
         <source>Inställningar</source>
       </segment>
     </unit>
+    <unit id="ViewOptions.ShowAllVariation">
+      <segment>
+        <source>Visa alla skillnader</source>
+      </segment>
+    </unit>
+    <unit id="ViewOptions.ShowNoVariation">
+      <segment>
+        <source>Visa inga skillnader</source>
+      </segment>
+    </unit>
+    <unit id="ViewOptions.ShowSubstantialVariation">
+      <segment>
+        <source>Visa substantiella skillnader</source>
+      </segment>
+    </unit>
     <unit id="ViewOptions.Textsize">
       <segment>
         <source>Textstorlek</source>
@@ -1519,6 +1534,11 @@
     <unit id="ViewOptions.ToggleAll">
       <segment>
         <source>Välj alla</source>
+      </segment>
+    </unit>
+    <unit id="ViewOptions.VariantOptions">
+      <segment>
+        <source>Visningsalternativ, varianter</source>
       </segment>
     </unit>
     <unit id="ViewOptions.WorkInfo">

--- a/src/theme/TEI/_tei-variants.scss
+++ b/src/theme/TEI/_tei-variants.scss
@@ -141,6 +141,44 @@ div.tei {
   }
 }
 
+div.tei.teiVariant {
+  &.show-variations-none {
+    .lemma,
+    .variant,
+    .orthographic,
+    .substantial,
+    .interpunction,
+    .identical,
+    .typographic,
+    .error {
+      background-color: unset !important;
+    }
+
+    .structVar {
+      display: none;
+    }
+
+    .variantScrollTarget {
+      cursor: default;
+    }
+  }
+
+  &.show-variations-sub {
+    .variant,
+    .orthographic,
+    .interpunction,
+    .identical,
+    .typographic,
+    .error {
+      background-color: unset !important;
+
+      &.variantScrollTarget {
+        cursor: default;
+      }
+    }
+  }
+}
+
 .teiVariant.ref_variant + .teiVariant.ref_variant {
   margin-left: -0.125em;
 }


### PR DESCRIPTION
Added config option `config.page.text.variantViewOptions` to allow the user to control the type of variation that is displayed in variant texts. It has two properties: `showVariationTypeOption`, which is a boolean used to control if the view option should be shown or not (defaults to `false`), and `defaultVariationType`, which is a string used to set the variation type that is shown by default. Possible values include `all` (default) for displaying all variation types, `sub` for displaying only substantial/significant variation, and `none` for hiding all variation highlighting. Example:

```typescript
export const config: Config = {
  /*...*/
  page: {
    /*...*/
    text: {
      /*...*/
      variantViewOptions: {
        showVariationTypeOption: true,
        defaultVariationType: "sub"
      },
      /*...*/
    },
    /*...*/
  },
  /*...*/
}
```