### PR TITLE
feature: add always present home button to main side menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Added
 
 - Site title to the top menu bar with link to the home page.
+- Home button to main side menu as an always present menu item.
 
 ### Fixed
 
@@ -53,6 +54,7 @@ div.tei .teiComment.noteReference {
     - Modifying imported font files should still be done in `global.scss`: use `@include meta.load-css()` instead of `@import` to include SCSS files with `@font-face` rules; to disable any of the four built-in fonts, comment out the respective `@include` lines.
     - Modifying TEI styles and styles for info-overlays and tooltips is no longer done in `global.scss`: instead, comment out the `@use` lines for the unused features from `theme/_inc-global-tei.scss` and `theme/_inc-global-optional.scss`.
 - Remove the option to show a logo to the right in the top menu bar. The config options controlling the appearance of the logo have been removed from `config.ts`: `showSiteLogo`, `siteLogoDefaultImageURL`, `siteLogoMobileImageURL`, `siteLogoLinkURL`, `siteLogoDimensions`.
+- Remove `component.mainSideMenu.items.home` from the config. The home button is always shown in the main side menu.
 
 
 

--- a/src/app/components/menus/main-side/main-side-menu.component.html
+++ b/src/app/components/menus/main-side/main-side-menu.component.html
@@ -12,6 +12,7 @@
           [attr.aria-haspopup]="item.children ? 'menu' : null"
           [attr.aria-expanded]="item.children ? (selectedMenu | arrayIncludes:item.nodeId) : null"
           role="menuitem"
+          [class.home-menu-item]="item.menuType === 'home'"
     >
       @if (!item.children) {
         <a
@@ -20,6 +21,9 @@
               [class.submenu-label]="item.children"
         >
           <ng-container *ngTemplateOutlet="menuItemContent; context: {$implicit: item}"/>
+          @if (item.menuType === 'home') {
+            <ion-icon aria-hidden="true" name="home-sharp" class="home-icon"></ion-icon>
+          }
         </a>
       }
       @if (item.children) {

--- a/src/app/components/menus/main-side/main-side-menu.component.scss
+++ b/src/app/components/menus/main-side/main-side-menu.component.scss
@@ -1,2 +1,27 @@
 // Import general styles for the side menu, these are common with the collection-side-menu
 @use "../../../../theme/common/side-menu.scss";
+
+li.home-menu-item {
+  background-color: var(--side-menu-back-button-background-color);
+  color: var(--side-menu-back-button-text-color);
+
+  ion-icon {
+    color: var(--side-menu-back-button-text-color);
+    font-size: 1.5rem;
+    margin-right: 0.5rem;
+
+    &.home-icon {
+      margin-inline-start: auto;
+    }
+  }
+
+  a {
+    height: 50px;
+    display: flex;
+    align-items: center;
+
+    .label {
+      border-bottom: 0;
+    }
+  }
+}

--- a/src/app/components/menus/main-side/main-side-menu.component.ts
+++ b/src/app/components/menus/main-side/main-side-menu.component.ts
@@ -100,6 +100,8 @@ export class MainSideMenuComponent implements OnInit, OnChanges {
         for (let i = 0; i < res.length; i++) {
           if (res[i].menuData && res[i].menuData.length) {
             for (let x = 0; x < res[i].menuData.length; x++) {
+              // Add the menu type to the menu data
+              res[i].menuData[x].menuType = res[i].menuType;
               menu.push(res[i].menuData[x]);
             }
           }
@@ -118,7 +120,13 @@ export class MainSideMenuComponent implements OnInit, OnChanges {
    * config.
    */
   private getMenuItemsArray(): Observable<any>[] {
-    const enabledPages = config.component?.mainSideMenu?.items ?? {};
+    // Get enabled menu items from config, and prepend with the home
+    // menu item, which is forced to always be shown.
+    let enabledPages = {
+      home: true,
+      ...(config.component?.mainSideMenu?.items ?? {})
+    };
+    enabledPages.home = true;
 
     const menuItemGetters: Record<string, () => Observable<any>> = {
       home: () => this.getHomePageMenuItem(),

--- a/src/assets/config/config.ts
+++ b/src/assets/config/config.ts
@@ -349,7 +349,6 @@ export const config: Config = {
     },
     mainSideMenu: {
       items: {
-        home: false,
         about: true,
         ebooks: true,
         collections: true,


### PR DESCRIPTION
The config option `component.mainSideMenu.items.home` is removed. The home button is always shown in the main side menu.