### PR TITLE
refactor: migrate `@Input` fields to `input()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 - Migrate constructor-based injection to the `inject` function.
 - Migrate `@Output` custom events to the `output()` API.
+- Migrate `@Input` fields to the `input()` API.
 - Deps: update `@angular/cli` to 20.2.0 and `@angular/core` to 20.2.1.
 - Deps: update `marked` to 16.2.0.
 - Deps (dev): update `@types/jasmine` to 5.1.9.

--- a/src/app/components/collection-text-types/comments/comments.component.ts
+++ b/src/app/components/collection-text-types/comments/comments.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, Input, NgZone, OnDestroy, OnInit, Renderer2, inject, output } from '@angular/core';
+import { Component, ElementRef, NgZone, OnDestroy, OnInit, Renderer2, inject, output, input } from '@angular/core';
 import { IonicModule, ModalController } from '@ionic/angular';
 
 import { IllustrationModal } from '@modals/illustration/illustration.modal';
@@ -28,8 +28,8 @@ export class CommentsComponent implements OnInit, OnDestroy {
   private scrollService = inject(ScrollService);
   viewOptionsService = inject(ViewOptionsService);
 
-  @Input() searchMatches: string[] = [];
-  @Input() textItemID: string = '';
+  readonly searchMatches = input<string[]>([]);
+  readonly textItemID = input<string>('');
   readonly openNewReadingTextView = output<string>();
   readonly setMobileModeActiveText = output<string>();
 
@@ -46,7 +46,7 @@ export class CommentsComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.mobileMode = this.platformService.isMobile();
 
-    if (this.textItemID) {
+    if (this.textItemID()) {
       this.loadCommentsText();
       this.getCorrespondanceMetadata();
     }
@@ -60,11 +60,11 @@ export class CommentsComponent implements OnInit, OnDestroy {
   }
 
   loadCommentsText() {
-    this.commentService.getComments(this.textItemID).subscribe({
+    this.commentService.getComments(this.textItemID()).subscribe({
       next: (text) => {
         if (text && String(text) !== 'File not found') {
-          this.text = this.parserService.insertSearchMatchTags(String(text), this.searchMatches);
-          if (this.searchMatches.length) {
+          this.text = this.parserService.insertSearchMatchTags(String(text), this.searchMatches());
+          if (this.searchMatches().length) {
             this.scrollService.scrollToFirstSearchMatch(this.elementRef.nativeElement, this.intervalTimerId);
           }
         } else {
@@ -79,7 +79,7 @@ export class CommentsComponent implements OnInit, OnDestroy {
   }
 
   getCorrespondanceMetadata() {
-    this.commentService.getCorrespondanceMetadata(this.textItemID.split('_')[1]).subscribe(
+    this.commentService.getCorrespondanceMetadata(this.textItemID().split('_')[1]).subscribe(
       (text: any) => {
         if (text?.subjects?.length > 0) {
           const senders: string[] = [];

--- a/src/app/components/collection-text-types/facsimiles/facsimiles.component.ts
+++ b/src/app/components/collection-text-types/facsimiles/facsimiles.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit, inject, output } from '@angular/core';
+import { Component, OnInit, inject, output, input } from '@angular/core';
 import { NgStyle } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { AlertButton, AlertController, AlertInput, IonicModule, ModalController } from '@ionic/angular';
@@ -25,10 +25,10 @@ export class FacsimilesComponent implements OnInit {
   private modalCtrl = inject(ModalController);
   private platformService = inject(PlatformService);
 
-  @Input() facsID: number | undefined = undefined;
-  @Input() imageNr: number | undefined = undefined;
-  @Input() sortOrder: number | undefined = undefined;
-  @Input() textItemID: string = '';
+  readonly facsID = input<number>();
+  readonly imageNr = input<number>();
+  readonly sortOrder = input<number>();
+  readonly textItemID = input<string>('');
   readonly selectedFacsID = output<number>();
   readonly selectedFacsName = output<string>();
   readonly selectedImageNr = output<number | null>();
@@ -62,19 +62,19 @@ export class FacsimilesComponent implements OnInit {
   ngOnInit() {
     this.mobileMode = this.platformService.isMobile();
 
-    if (this.textItemID) {
+    if (this.textItemID()) {
       this.loadFacsimiles();
     }
   }
 
   loadFacsimiles() {
-    this.collectionContentService.getFacsimiles(this.textItemID).subscribe({
+    this.collectionContentService.getFacsimiles(this.textItemID()).subscribe({
       next: (facs) => {
         if (facs && facs.length > 0) {
-          const sectionId = this.textItemID.split('_')[2]?.split(';')[0]?.replace('ch', '') || '';
+          const sectionId = this.textItemID().split('_')[2]?.split(';')[0]?.replace('ch', '') || '';
           for (const f of facs) {
             const facsimile = new Facsimile(f);
-            facsimile.itemId = this.textItemID;
+            facsimile.itemId = this.textItemID();
             facsimile.manuscript_id = f.publication_manuscript_id;
             if (!f['external_url']) {
               facsimile.title = f['title'];
@@ -111,20 +111,21 @@ export class FacsimilesComponent implements OnInit {
 
   setInitialFacsimile() {
     if (this.facsimiles.length > 0) {
-      if (this.facsID !== undefined && this.facsID > 0) {
+      const facsID = this.facsID();
+      if (facsID !== undefined && facsID > 0) {
         const inputFacsimile = this.facsimiles.filter((item: any) => {
-          return (item.facsimile_id === this.facsID);
+          return (item.facsimile_id === this.facsID());
         })[0];
         this.selectedFacsimile = inputFacsimile ? inputFacsimile : this.facsimiles[0];
-      } else if (this.sortOrder) {
+      } else if (this.sortOrder()) {
         const inputFacsimile = this.facsimiles.filter((item: any) => {
-          return (item.priority === this.sortOrder);
+          return (item.priority === this.sortOrder());
         })[0];
         this.selectedFacsimile = inputFacsimile ? inputFacsimile : this.facsimiles[0];
       } else if (
         this.externalFacsimiles.length > 0 && 
         (
-          (this.facsID !== undefined && this.facsID < 1) ||
+          (facsID !== undefined && facsID < 1) ||
           this.externalFacsimiles[0]['priority'] < this.facsimiles[0]['priority']
         )
       ) {
@@ -136,7 +137,7 @@ export class FacsimilesComponent implements OnInit {
       }
   
       if (this.selectedFacsimile) {
-        this.initializeDisplayedFacsimile(this.selectedFacsimile, this.imageNr);
+        this.initializeDisplayedFacsimile(this.selectedFacsimile, this.imageNr());
       }
     } else {
       this.selectedFacsimileIsExternal = true;

--- a/src/app/components/collection-text-types/illustrations/illustrations.component.ts
+++ b/src/app/components/collection-text-types/illustrations/illustrations.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, OnInit, SimpleChanges, inject, output } from '@angular/core';
+import { Component, OnChanges, OnInit, SimpleChanges, inject, output, input } from '@angular/core';
 import { NgClass } from '@angular/common';
 import { IonicModule, ModalController } from '@ionic/angular';
 
@@ -20,8 +20,8 @@ export class IllustrationsComponent implements OnChanges, OnInit {
   private platformService = inject(PlatformService);
   private scrollService = inject(ScrollService);
 
-  @Input() singleImage: Record<string, any> | undefined = undefined;
-  @Input() textItemID: string = '';
+  readonly singleImage = input<Record<string, any>>();
+  readonly textItemID = input<string>('');
   readonly showAllImages = output<any>();
   readonly setMobileModeActiveText = output<string>();
   
@@ -37,13 +37,14 @@ export class IllustrationsComponent implements OnChanges, OnInit {
     for (const propName in changes) {
       if (changes.hasOwnProperty(propName)) {
         if (propName === 'singleImage') {
+          const singleImage = this.singleImage();
           if (
             !changes.singleImage.firstChange &&
-            typeof this.singleImage !== 'undefined' &&
-            this.singleImage
+            typeof singleImage !== 'undefined' &&
+            singleImage
           ) {
             this.images = [];
-            this.images.push(this.singleImage);
+            this.images.push(singleImage);
             this.viewAll = false;
           }
         }
@@ -54,20 +55,21 @@ export class IllustrationsComponent implements OnChanges, OnInit {
   ngOnInit() {
     this.mobileMode = this.platformService.isMobile();
 
-    if (this.textItemID) {
+    if (this.textItemID()) {
       this.getIllustrationImages();
     }
   }
 
   private getIllustrationImages() {
-    this.parserService.getReadingTextIllustrations(this.textItemID).subscribe(
+    this.parserService.getReadingTextIllustrations(this.textItemID()).subscribe(
       (images: any[]) => {
         this.images = images;
         this.imageCountTotal = this.images.length;
         this.imagesCache = this.images;
-        if (typeof this.singleImage !== 'undefined' && this.singleImage) {
+        const singleImage = this.singleImage();
+        if (typeof singleImage !== 'undefined' && singleImage) {
           this.images = [];
-          this.images.push(this.singleImage);
+          this.images.push(singleImage);
           this.viewAll = false;
         }
         this.imgLoading = false;

--- a/src/app/components/collection-text-types/legend/legend.component.ts
+++ b/src/app/components/collection-text-types/legend/legend.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, Input, LOCALE_ID, NgZone, OnDestroy, OnInit, Renderer2, inject } from '@angular/core';
+import { Component, ElementRef, LOCALE_ID, NgZone, OnDestroy, OnInit, Renderer2, inject, input } from '@angular/core';
 import { AsyncPipe } from '@angular/common';
 import { IonicModule } from '@ionic/angular';
 import { catchError, map, Observable, of } from 'rxjs';
@@ -23,8 +23,8 @@ export class LegendComponent implements OnDestroy, OnInit {
   private scrollService = inject(ScrollService);
   private activeLocale = inject(LOCALE_ID);
 
-  @Input() itemId?: string;
-  @Input() scrollToElementId?: string;
+  readonly itemId = input<string>();
+  readonly scrollToElementId = input<string>();
 
   collectionId: string = '';
   intervalTimerId: number = 0;
@@ -35,8 +35,8 @@ export class LegendComponent implements OnDestroy, OnInit {
   private unlistenClickEvents?: () => void;
 
   ngOnInit() {
-    this.collectionId = this.itemId?.split('_')[0] || '';
-    this.publicationId = this.itemId?.split('_')[1].split(';')[0] || '';
+    this.collectionId = this.itemId()?.split('_')[0] || '';
+    this.publicationId = this.itemId()?.split('_')[1].split(';')[0] || '';
 
     this.text$ = this.getMdContent(this.activeLocale + '-' + this.staticMdLegendFolderNumber + '-' + this.collectionId + '-' + this.publicationId);
     if (isBrowser()) {
@@ -104,7 +104,7 @@ export class LegendComponent implements OnDestroy, OnInit {
    * last text-legend-element into view.
    */
   scrollToInitialTextPosition() {
-    if (this.scrollToElementId) {
+    if (this.scrollToElementId()) {
       const that = this;
       this.ngZone.runOutsideAngular(() => {
         let iterationsLeft = 10;
@@ -116,7 +116,7 @@ export class LegendComponent implements OnDestroy, OnInit {
           } else {
             iterationsLeft -= 1;
             const legendElements = document.querySelectorAll('page-text:not([ion-page-hidden]):not(.ion-page-hidden) text-legend');
-            const element = legendElements[legendElements.length - 1].querySelector('[data-id="' + that.scrollToElementId + '"]') as any;
+            const element = legendElements[legendElements.length - 1].querySelector('[data-id="' + that.scrollToElementId() + '"]') as any;
             if (element) {
               that.scrollService.scrollElementIntoView(element, 'top');
               clearInterval(that.intervalTimerId);

--- a/src/app/components/collection-text-types/manuscripts/manuscripts.component.ts
+++ b/src/app/components/collection-text-types/manuscripts/manuscripts.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, Input, OnInit, inject, output } from '@angular/core';
+import { Component, ElementRef, OnInit, inject, output, input } from '@angular/core';
 import { AlertButton, AlertController, AlertInput, IonicModule } from '@ionic/angular';
 
 import { config } from '@config';
@@ -23,9 +23,9 @@ export class ManuscriptsComponent implements OnInit {
   private scrollService = inject(ScrollService);
   viewOptionsService = inject(ViewOptionsService);
 
-  @Input() msID: number | undefined = undefined;
-  @Input() searchMatches: string[] = [];
-  @Input() textItemID: string = '';
+  readonly msID = input<number>();
+  readonly searchMatches = input<string[]>([]);
+  readonly textItemID = input<string>('');
   readonly openNewLegendView = output<any>();
   readonly openNewManView = output<any>();
   readonly selectedMsID = output<number>();
@@ -48,13 +48,13 @@ export class ManuscriptsComponent implements OnInit {
   }
 
   ngOnInit() {
-    if (this.textItemID) {
+    if (this.textItemID()) {
       this.loadManuscriptTexts();
     }
   }
 
   loadManuscriptTexts() {
-    this.collectionContentService.getManuscripts(this.textItemID).subscribe({
+    this.collectionContentService.getManuscripts(this.textItemID()).subscribe({
       next: (res) => {
         if (
           res?.manuscripts?.length > 0 &&
@@ -62,7 +62,7 @@ export class ManuscriptsComponent implements OnInit {
         ) {
           this.manuscripts = res.manuscripts;
           this.setManuscript();
-          if (this.searchMatches.length) {
+          if (this.searchMatches().length) {
             this.scrollService.scrollToFirstSearchMatch(this.elementRef.nativeElement, this.intervalTimerId);
           }
         } else {
@@ -77,9 +77,9 @@ export class ManuscriptsComponent implements OnInit {
   }
 
   setManuscript() {
-    if (this.msID) {
+    if (this.msID()) {
       const inputManuscript = this.manuscripts.filter((item: any) => {
-        return (item.id === this.msID);
+        return (item.id === this.msID());
       })[0];
       if (inputManuscript) {
         this.selectedManuscript = inputManuscript;
@@ -112,7 +112,7 @@ export class ManuscriptsComponent implements OnInit {
             ? this.selectedManuscript.manuscript_normalized
             : this.selectedManuscript.manuscript_changes;
       text = this.parserService.postprocessManuscriptText(text);
-      this.text = this.parserService.insertSearchMatchTags(text, this.searchMatches);
+      this.text = this.parserService.insertSearchMatchTags(text, this.searchMatches());
 
       this.textLanguage = this.selectedManuscript.language
             ? this.selectedManuscript.language

--- a/src/app/components/collection-text-types/metadata/metadata.component.ts
+++ b/src/app/components/collection-text-types/metadata/metadata.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, LOCALE_ID, OnInit, inject } from '@angular/core';
+import { Component, LOCALE_ID, OnInit, inject, input } from '@angular/core';
 import { AsyncPipe } from '@angular/common';
 import { IonicModule } from '@ionic/angular';
 import { catchError, Observable, of, Subject } from 'rxjs';
@@ -16,14 +16,14 @@ export class MetadataComponent implements OnInit {
   private collectionContentService = inject(CollectionContentService);
   private activeLocale = inject(LOCALE_ID);
 
-  @Input() textItemID: string = '';
+  readonly textItemID = input<string>('');
 
   loadingError$: Subject<boolean> = new Subject<boolean>();
   metadata$: Observable<any>;
 
   ngOnInit() {
     this.metadata$ = this.collectionContentService.getMetadata(
-      this.textItemID.split('_')[1] || '0', this.activeLocale
+      this.textItemID().split('_')[1] || '0', this.activeLocale
     ).pipe(
       catchError((error) => {
         console.error('Error loading metadata', error);

--- a/src/app/components/collection-text-types/variants/variants.component.ts
+++ b/src/app/components/collection-text-types/variants/variants.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, Input, OnInit, inject, output } from '@angular/core';
+import { Component, ElementRef, OnInit, inject, output, input } from '@angular/core';
 import { AlertButton, AlertController, AlertInput, IonicModule } from '@ionic/angular';
 
 import { config } from '@config';
@@ -23,10 +23,10 @@ export class VariantsComponent implements OnInit {
   private scrollService = inject(ScrollService);
   viewOptionsService = inject(ViewOptionsService);
 
-  @Input() searchMatches: Array<string> = [];
-  @Input() sortOrder: number | undefined = undefined;
-  @Input() textItemID: string = '';
-  @Input() varID: number | undefined = undefined;
+  readonly searchMatches = input<Array<string>>([]);
+  readonly sortOrder = input<number>();
+  readonly textItemID = input<string>('');
+  readonly varID = input<number>();
   readonly openNewLegendView = output<any>();
   readonly openNewVarView = output<any>();
   readonly selectedVarID = output<number>();
@@ -44,18 +44,18 @@ export class VariantsComponent implements OnInit {
   }
 
   ngOnInit() {
-    if (this.textItemID) {
+    if (this.textItemID()) {
       this.loadVariantTexts();
     }
   }
 
   loadVariantTexts() {
-    this.collectionContentService.getVariants(this.textItemID).subscribe({
+    this.collectionContentService.getVariants(this.textItemID()).subscribe({
       next: (res) => {
         if (res?.variations?.length > 0) {
           this.variants = res.variations;
           this.setVariant();
-          if (this.searchMatches.length) {
+          if (this.searchMatches().length) {
             this.scrollService.scrollToFirstSearchMatch(this.elementRef.nativeElement, this.intervalTimerId);
           }
         } else {
@@ -70,14 +70,14 @@ export class VariantsComponent implements OnInit {
   }
 
   setVariant() {
-    if (this.varID) {
+    if (this.varID()) {
       const inputVariant = this.variants.filter((item: any) => {
-        return (item.id === this.varID);
+        return (item.id === this.varID());
       })[0];
       this.selectedVariant = inputVariant ? inputVariant : this.variants[0];
-    } else if (this.sortOrder) {
+    } else if (this.sortOrder()) {
       const inputVariant = this.variants.filter((item: any) => {
-        return (item.sort_order === this.sortOrder);
+        return (item.sort_order === this.sortOrder());
       })[0];
       this.selectedVariant = inputVariant ? inputVariant : this.variants[0];
     } else {
@@ -97,7 +97,7 @@ export class VariantsComponent implements OnInit {
     }
     if (this.selectedVariant) {
       let text = this.parserService.postprocessVariantText(this.selectedVariant.content);
-      this.text = this.parserService.insertSearchMatchTags(text, this.searchMatches);
+      this.text = this.parserService.insertSearchMatchTags(text, this.searchMatches());
     }
   }
 

--- a/src/app/components/date-histogram/date-histogram.component.html
+++ b/src/app/components/date-histogram/date-histogram.component.html
@@ -85,7 +85,7 @@
 
 <div class="histogram-wrapper">
   <div class="diagram">
-    @for (year of yearsAll; track year.key_as_string) {
+    @for (year of yearsAll(); track year.key_as_string) {
       <div class="year" [ngClass]="{'yearIsDecade': isDecade(year)}" (click)="selectYear(year)">
         <div class="yearBar" [ngClass]="{'yearBarInRange': isYearInRange(year)}" [style.width]="getYearRelativeToMax(year)"></div>
         <div class="yearDetails">{{year.key_as_string}}: {{year.doc_count_current}}</div>

--- a/src/app/components/menus/collection-side/collection-side-menu.component.html
+++ b/src/app/components/menus/collection-side/collection-side-menu.component.html
@@ -48,29 +48,29 @@
   }
   <ul role="menu" [ngClass]="activeMenuOrder + '-menu-sorting'">
     @if (enableCover) {
-      <li [attr.aria-current]="routeUrlSegments[2].path === 'cover' ? 'page' : null" role="menuitem" data-id="toc_cover">
-        <a routerLink="{{collectionID | collectionPagePath:'cover'}}" [class.menu-highlight]="routeUrlSegments[2].path === 'cover'">
+      <li [attr.aria-current]="routeUrlSegments()?.[2]?.path === 'cover' ? 'page' : null" role="menuitem" data-id="toc_cover">
+        <a routerLink="{{collectionID() | collectionPagePath:'cover'}}" [class.menu-highlight]="routeUrlSegments()?.[2]?.path === 'cover'">
           <span class="label">{{ coverPageName }}</span>
         </a>
       </li>
     }
     @if (enableTitle) {
-      <li [attr.aria-current]="routeUrlSegments[2].path === 'title' ? 'page' : null" role="menuitem" data-id="toc_title">
-        <a routerLink="{{collectionID | collectionPagePath:'title'}}" [class.menu-highlight]="routeUrlSegments[2].path === 'title'">
+      <li [attr.aria-current]="routeUrlSegments()?.[2]?.path === 'title' ? 'page' : null" role="menuitem" data-id="toc_title">
+        <a routerLink="{{collectionID() | collectionPagePath:'title'}}" [class.menu-highlight]="routeUrlSegments()?.[2]?.path === 'title'">
           <span class="label">{{ titlePageName }}</span>
         </a>
       </li>
     }
     @if (enableForeword) {
-      <li [attr.aria-current]="routeUrlSegments[2].path === 'foreword' ? 'page' : null" role="menuitem" data-id="toc_foreword">
-        <a routerLink="{{collectionID | collectionPagePath:'foreword'}}" [class.menu-highlight]="routeUrlSegments[2].path === 'foreword'">
+      <li [attr.aria-current]="routeUrlSegments()?.[2]?.path === 'foreword' ? 'page' : null" role="menuitem" data-id="toc_foreword">
+        <a routerLink="{{collectionID() | collectionPagePath:'foreword'}}" [class.menu-highlight]="routeUrlSegments()?.[2]?.path === 'foreword'">
           <span class="label">{{ forewordPageName }}</span>
         </a>
       </li>
     }
     @if (enableIntroduction) {
-      <li [attr.aria-current]="routeUrlSegments[2].path === 'introduction' ? 'page' : null" role="menuitem" data-id="toc_introduction">
-        <a routerLink="{{collectionID | collectionPagePath:'introduction'}}" [class.menu-highlight]="routeUrlSegments[2].path === 'introduction'">
+      <li [attr.aria-current]="routeUrlSegments()?.[2]?.path === 'introduction' ? 'page' : null" role="menuitem" data-id="toc_introduction">
+        <a routerLink="{{collectionID() | collectionPagePath:'introduction'}}" [class.menu-highlight]="routeUrlSegments()?.[2]?.path === 'introduction'">
           <span class="label">{{ introductionPageName }}</span>
         </a>
       </li>

--- a/src/app/components/menus/main-side/main-side-menu.component.ts
+++ b/src/app/components/menus/main-side/main-side-menu.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, LOCALE_ID, OnChanges, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, LOCALE_ID, OnChanges, OnInit, inject, input } from '@angular/core';
 import { NgTemplateOutlet } from '@angular/common';
 import { RouterLink, UrlSegment } from '@angular/router';
 import { IonicModule } from '@ionic/angular';
@@ -39,7 +39,7 @@ export class MainSideMenuComponent implements OnInit, OnChanges {
   private mediaCollectionService = inject(MediaCollectionService);
   private activeLocale = inject(LOCALE_ID);
 
-  @Input() urlSegments: UrlSegment[] = [];
+  readonly urlSegments = input<UrlSegment[]>([]);
 
   highlightedMenu: string = '';
   mainMenu: any[] = [];
@@ -364,7 +364,7 @@ export class MainSideMenuComponent implements OnInit, OnChanges {
   private updateHighlightedMenuItem() {
     // Create a path string from all route segments, prefixed with a slash
     // (e.g., '/ebook/pdf/title-of-the-ebook')
-    const currentPath = '/' + (this.urlSegments?.map(segment => segment.path).join('/') || '');
+    const currentPath = '/' + (this.urlSegments()?.map(segment => segment.path).join('/') || '');
 
     const currentItemRoot = this.recursiveFindCurrentMenuItem(this.mainMenu, currentPath);
     if (!currentItemRoot) {
@@ -390,7 +390,7 @@ export class MainSideMenuComponent implements OnInit, OnChanges {
           this.headService.setTitle([String(item.title), $localize`:@@MainSideMenu.MediaCollections:Bildbank`]);
         } else if (
           !this.topMenuItems.includes(item.parentPath) &&
-          this.urlSegments[0]?.path !== 'collection'
+          this.urlSegments()[0]?.path !== 'collection'
         ) {
           // For top menu items the title is set by app.component, and
           // for collections the title is set by the text-changer component

--- a/src/app/components/menus/top/top-menu.component.html
+++ b/src/app/components/menus/top/top-menu.component.html
@@ -4,11 +4,11 @@
     <button (click)="toggleSideMenu($event)"
           type="button"
           aria-haspopup="menu"
-          [attr.aria-expanded]="showSideNav"
+          [attr.aria-expanded]="showSideNav()"
           aria-controls="side-navigation"
     >
-      <ion-icon [class.visuallyhidden]="showSideNav" name="menu-sharp"></ion-icon>
-      <ion-icon [class.visuallyhidden]="!showSideNav" name="close-sharp"></ion-icon>
+      <ion-icon [class.visuallyhidden]="showSideNav()" name="menu-sharp"></ion-icon>
+      <ion-icon [class.visuallyhidden]="!showSideNav()" name="close-sharp"></ion-icon>
       <span class="side-title" i18n="@@TopMenu.Menu">Meny</span>
     </button>
   </li>
@@ -54,7 +54,7 @@
         @for (lang of languages; track lang.code) {
           @if (lang.code !== activeLocale) {
             <li lang="{{lang.code}}" role="menuitem">
-              <a href="{{_window.location.origin + '/' + lang.code + currentRouterUrl}}">{{lang.label}} ({{lang.code}})</a>
+              <a href="{{_window.location.origin + '/' + lang.code + currentRouterUrl()}}">{{lang.label}} ({{lang.code}})</a>
             </li>
           }
         }

--- a/src/app/components/menus/top/top-menu.component.ts
+++ b/src/app/components/menus/top/top-menu.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, LOCALE_ID, OnDestroy, OnInit, DOCUMENT, inject, output } from '@angular/core';
+import { Component, LOCALE_ID, OnDestroy, OnInit, DOCUMENT, inject, output, input } from '@angular/core';
 import { NgStyle } from '@angular/common';
 import { RouterLink } from '@angular/router';
 import { IonicModule } from '@ionic/angular';
@@ -17,8 +17,8 @@ export class TopMenuComponent implements OnDestroy, OnInit {
   activeLocale = inject(LOCALE_ID);
   private document = inject<Document>(DOCUMENT);
 
-  @Input() currentRouterUrl: string = '';
-  @Input() showSideNav: boolean = false;
+  readonly currentRouterUrl = input<string>('');
+  readonly showSideNav = input<boolean>(false);
   readonly sideNavClick = output();
 
   currentLanguageLabel: string = '';

--- a/src/app/components/occurrences-accordion/occurrences-accordion.component.html
+++ b/src/app/components/occurrences-accordion/occurrences-accordion.component.html
@@ -54,7 +54,7 @@
   </ul>
 }
 
-@if (simpleWorkMetadata && (type === 'work' || type === 'work_manifestation')) {
+@if (simpleWorkMetadata && (type() === 'work' || type() === 'work_manifestation')) {
   <p i18n="@@NamedEntity.WorkOccurrencesUnavailable">Förekomster för verk är inte tillgängliga.</p>
 } @else {
   @if (!isLoading && occurrenceData.length < 1) {

--- a/src/app/components/occurrences-accordion/occurrences-accordion.component.ts
+++ b/src/app/components/occurrences-accordion/occurrences-accordion.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit, inject } from '@angular/core';
+import { Component, OnInit, inject, input } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { IonicModule } from '@ionic/angular';
 import { take } from 'rxjs';
@@ -23,8 +23,8 @@ export class OccurrencesAccordionComponent implements OnInit {
   private namedEntityService = inject(NamedEntityService);
   private tocService = inject(CollectionTableOfContentsService);
 
-  @Input() id: number | undefined = undefined;
-  @Input() type: string = '';
+  readonly id = input<number>();
+  readonly type = input<string>('');
 
   groupedTexts: any[] = [];
   isLoading: boolean = true;
@@ -37,26 +37,28 @@ export class OccurrencesAccordionComponent implements OnInit {
   }
 
   ngOnInit() {
-    if (this.type === 'keyword') {
+    const type = this.type();
+    if (type === 'keyword') {
       this.showPublishedStatus = config.page?.index?.keywords?.publishedStatus ?? 2;
-    } else if (this.type === 'person') {
+    } else if (type === 'person') {
       this.showPublishedStatus = config.page?.index?.persons?.publishedStatus ?? 2;
-    } else if (this.type === 'place') {
+    } else if (type === 'place') {
       this.showPublishedStatus = config.page?.index?.places?.publishedStatus ?? 2;
-    } else if (this.type === 'work') {
+    } else if (type === 'work') {
       this.showPublishedStatus = config.page?.index?.works?.publishedStatus ?? 2;
     }
 
-    if (this.type === 'work' && this.simpleWorkMetadata) {
+    const id = this.id();
+    if (type === 'work' && this.simpleWorkMetadata) {
       this.isLoading = false;
-    } else if (this.id && this.type) {
-      this.getOccurrenceData(this.id);
+    } else if (id && type) {
+      this.getOccurrenceData(id);
     }
   }
 
   private getOccurrenceData(id: any) {
     this.isLoading = true;
-    let objectType = this.type;
+    let objectType = this.type();
     if (objectType === 'work') {
       objectType = 'work_manifestation';
     }

--- a/src/app/components/pdf-viewer/pdf-viewer.component.html
+++ b/src/app/components/pdf-viewer/pdf-viewer.component.html
@@ -99,7 +99,7 @@
   @if (pdfURL$ | async; as pdfURL) {
     <object [data]="pdfURL" type="application/pdf">
       <p class="no-support">
-        <ng-container i18n="@@PdfViewer.NoBrowserSupport">Din webbläsare stöder inte PDF-filer. Ladda ner PDF:en för att läsa den:</ng-container>&nbsp;<a [href]="pdfURL" i18n="@@PdfViewer.DownloadPdf" [download]="pdfFileName">ladda ner PDF</a>.
+        <ng-container i18n="@@PdfViewer.NoBrowserSupport">Din webbläsare stöder inte PDF-filer. Ladda ner PDF:en för att läsa den:</ng-container>&nbsp;<a [href]="pdfURL" i18n="@@PdfViewer.DownloadPdf" [download]="pdfFileName()">ladda ner PDF</a>.
       </p>
     </object>
   }

--- a/src/app/components/pdf-viewer/pdf-viewer.component.ts
+++ b/src/app/components/pdf-viewer/pdf-viewer.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, LOCALE_ID, OnInit, ViewChild, DOCUMENT, inject } from '@angular/core';
+import { Component, LOCALE_ID, OnInit, ViewChild, DOCUMENT, inject, input } from '@angular/core';
 import { AsyncPipe, NgStyle } from '@angular/common';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { ActivatedRoute } from '@angular/router';
@@ -24,7 +24,7 @@ export class PdfViewerComponent implements OnInit {
   private activeLocale = inject(LOCALE_ID);
   private document = inject<Document>(DOCUMENT);
 
-  @Input() pdfFileName: string = '';
+  readonly pdfFileName = input<string>('');
   @ViewChild('downloadOptionsPopover') downloadOptionsPopover: any;
   
   downloadPopoverIsOpen: boolean = false;
@@ -41,8 +41,9 @@ export class PdfViewerComponent implements OnInit {
 
   ngOnInit() {
     const availableEbooks: any[] = config.ebooks ?? [];
+    const pdfFileName = this.pdfFileName();
     for (const ebook of availableEbooks) {
-      if (ebook.filename === this.pdfFileName) {
+      if (ebook.filename === pdfFileName) {
         this.pdfData = ebook;
         break;
       }
@@ -56,7 +57,7 @@ export class PdfViewerComponent implements OnInit {
                   this._window?.location.pathname.split('/')[1] === this.activeLocale
                   ? '/' + this.activeLocale : ''
                 )
-              + '/assets/ebooks/' + this.pdfFileName
+              + '/assets/ebooks/' + pdfFileName
             );
 
     this.pdfURL$ = this.route.queryParamMap.pipe(

--- a/src/app/components/static-html/static-html.component.html
+++ b/src/app/components/static-html/static-html.component.html
@@ -1,1 +1,1 @@
-<div [class.static-collection-toc]="type == 'collection-toc'" [innerHTML]="staticContent$ | async"></div>
+<div [class.static-collection-toc]="type() == 'collection-toc'" [innerHTML]="staticContent$ | async"></div>

--- a/src/app/components/static-html/static-html.component.ts
+++ b/src/app/components/static-html/static-html.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, SimpleChanges, inject } from '@angular/core';
+import { Component, OnChanges, SimpleChanges, inject, input } from '@angular/core';
 import { AsyncPipe } from '@angular/common';
 import { Observable, of } from 'rxjs';
 
@@ -16,8 +16,8 @@ import { isBrowser } from '@utility-functions';
 export class StaticHtmlComponent implements OnChanges {
   private tocService = inject(CollectionTableOfContentsService);
 
-  @Input() type: string = '';
-  @Input() id: string = '';
+  readonly type = input<string>('');
+  readonly id = input<string>('');
 
   prebuiltCollectionMenus: boolean = true;
   staticContent$: Observable<string>;
@@ -46,7 +46,7 @@ export class StaticHtmlComponent implements OnChanges {
       }
     }
 
-    if (inputChanged && this.type && this.id) {
+    if (inputChanged && this.type() && this.id()) {
       this.staticContent$ = this.getStaticContent();
     }
   }
@@ -56,8 +56,8 @@ export class StaticHtmlComponent implements OnChanges {
     // TOC files is enabled in config and running on the server. In the
     // browser the dynamic TOC is loaded, so no need to first render the
     // static one.
-    if (this.type === 'collection-toc' && this.prebuiltCollectionMenus && !isBrowser()) {
-      return this.tocService.getStaticTableOfContents(this.id);
+    if (this.type() === 'collection-toc' && this.prebuiltCollectionMenus && !isBrowser()) {
+      return this.tocService.getStaticTableOfContents(this.id());
     }
 
     return of('');

--- a/src/app/components/text-changer/text-changer.component.ts
+++ b/src/app/components/text-changer/text-changer.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, OnDestroy, OnInit, SimpleChanges, inject } from '@angular/core';
+import { Component, OnChanges, OnDestroy, OnInit, SimpleChanges, inject, input } from '@angular/core';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { IonicModule } from '@ionic/angular';
 import { combineLatestWith, distinctUntilChanged, filter, map, Subscription } from 'rxjs';
@@ -31,13 +31,13 @@ export class TextChangerComponent implements OnChanges, OnDestroy, OnInit {
   private route = inject(ActivatedRoute);
   private tocService = inject(CollectionTableOfContentsService);
 
-  @Input() parentPageType: string = 'text';
+  readonly parentPageType = input<string>('text');
   // ionViewActive is true when the parent page component is active in the DOM,
   // i.e. the component has entered the Ionic life cycle hook ionViewWillEnter.
   // Set to false when the parent component has entered ionViewWillLeave life
   // cycle hook. This way we can react to ActivatedRoute changes only in active
   // components.
-  @Input() ionViewActive: boolean = true;
+  readonly ionViewActive = input<boolean>(true);
 
   activeMenuOrder: string = '';
   collectionId: string = '';
@@ -65,7 +65,7 @@ export class TextChangerComponent implements OnChanges, OnDestroy, OnInit {
     // (the received TOC is already properly ordered) and to route
     // parameters, then act on changes to either.
     this.tocSubscr = this.tocService.getCurrentFlattenedCollectionToc().pipe(
-      filter(toc => this.ionViewActive && !!toc),
+      filter(toc => this.ionViewActive() && !!toc),
       combineLatestWith(this.route.paramMap, this.route.queryParamMap),
       map(([toc, paramMap, queryParamMap]) => ({
         toc,
@@ -169,7 +169,7 @@ export class TextChangerComponent implements OnChanges, OnDestroy, OnInit {
       if (!item.page && item.itemId === this.tocItemId) {
         return true;
       }
-      return item.page === this.parentPageType;
+      return item.page === this.parentPageType();
     });
   }
 }

--- a/src/app/directives/draggable-image.directive.ts
+++ b/src/app/directives/draggable-image.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, Input, NgZone, OnDestroy, OnInit, Renderer2, inject, output } from '@angular/core';
+import { Directive, ElementRef, NgZone, OnDestroy, OnInit, Renderer2, inject, output, input } from '@angular/core';
 
 
 @Directive({
@@ -10,10 +10,10 @@ export class DraggableImageDirective implements OnInit, OnDestroy {
   private ngZone = inject(NgZone);
   private renderer = inject(Renderer2);
 
-  @Input('draggableImage') initialCoordinates: number[] = [0, 0];
-  @Input() angle: number = 0;
-  @Input() zoom: number = 1;
-  @Input() mouseOnly: boolean = false;
+  readonly initialCoordinates = input<number[]>([0, 0], { alias: "draggableImage" });
+  readonly angle = input<number>(0);
+  readonly zoom = input<number>(1);
+  readonly mouseOnly = input<boolean>(false);
   readonly finalCoordinates = output<number[]>();
 
   private activeDrag: boolean = false;
@@ -53,7 +53,7 @@ export class DraggableImageDirective implements OnInit, OnDestroy {
       }
     );
 
-    if (!this.mouseOnly) {
+    if (!this.mouseOnly()) {
       this.unlistenTouchStartEvents = this.renderer.listen(
         this.elRef.nativeElement, 'touchstart', (event: any) => {
           this.ngZone.runOutsideAngular(() => {
@@ -121,7 +121,7 @@ export class DraggableImageDirective implements OnInit, OnDestroy {
       if (this.elRef.nativeElement) {
         this.renderer.setStyle(
           this.elRef.nativeElement,
-          'transform', 'scale(' + this.zoom + ') translate3d(' + this.currentCoordinates[0] + 'px, ' + this.currentCoordinates[1] + 'px, 0px) rotate(' + this.angle + 'deg)'
+          'transform', 'scale(' + this.zoom() + ') translate3d(' + this.currentCoordinates[0] + 'px, ' + this.currentCoordinates[1] + 'px, 0px) rotate(' + this.angle() + 'deg)'
         );
       }
     }
@@ -149,8 +149,8 @@ export class DraggableImageDirective implements OnInit, OnDestroy {
       deltaY = event.clientY - this.offsetY;
     }
 
-    x = this.initialCoordinates[0] + deltaX / this.zoom;
-    y = this.initialCoordinates[1] + deltaY / this.zoom;
+    x = this.initialCoordinates()[0] + deltaX / this.zoom();
+    y = this.initialCoordinates()[1] + deltaY / this.zoom();
 
     return [x, y];
   }

--- a/src/app/directives/math-jax.directive.ts
+++ b/src/app/directives/math-jax.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, Input, OnChanges, inject } from '@angular/core';
+import { Directive, ElementRef, OnChanges, inject, input } from '@angular/core';
 import { SafeHtml } from '@angular/platform-browser';
 
 import { config } from '@config';
@@ -18,7 +18,7 @@ declare var MathJax: {
 export class MathJaxDirective implements OnChanges {
   private elRef = inject(ElementRef);
 
-  @Input('MathJax') mathJaxInput: string | SafeHtml | null = null;
+  readonly mathJaxInput = input<string | SafeHtml | null>(null, { alias: "MathJax" });
 
   private mathJaxEnabled: boolean = false;
 
@@ -27,7 +27,7 @@ export class MathJaxDirective implements OnChanges {
   }
 
   ngOnChanges() {
-    if (isBrowser() && this.mathJaxEnabled && this.mathJaxInput) {
+    if (isBrowser() && this.mathJaxEnabled && this.mathJaxInput()) {
       try {
         // Tell the MathJax-processor to convert any TeX notated math in this.elRef.nativeElement
         MathJax.Hub.Queue(['Typeset', MathJax.Hub, this.elRef.nativeElement]);


### PR DESCRIPTION
`@Input()` decorator-based fields could not be migrated for any Ionic modals or popovers because Ionic 8.2.2 does not support input signals.