### PR TITLE
refactor: collection text id handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - Migrate `@Output` custom events to the `output()` API.
 - Migrate `@Input` fields to the `input()` API.
 - Migrate decorator query fields to signal queries.
+- Refactor collection text id handling.
 - Deps: update `@angular/cli` to 20.2.0 and `@angular/core` to 20.2.1.
 - Deps: update `marked` to 16.2.0.
 - Deps (dev): update `@types/jasmine` to 5.1.9.

--- a/src/app/components/collection-text-types/comments/comments.component.ts
+++ b/src/app/components/collection-text-types/comments/comments.component.ts
@@ -2,6 +2,7 @@ import { Component, ElementRef, NgZone, OnDestroy, OnInit, Renderer2, inject, ou
 import { IonicModule, ModalController } from '@ionic/angular';
 
 import { IllustrationModal } from '@modals/illustration/illustration.modal';
+import { TextKey } from '@models/collection.model';
 import { TrustHtmlPipe } from '@pipes/trust-html.pipe';
 import { CommentService } from '@services/comment.service';
 import { HtmlParserService } from '@services/html-parser.service';
@@ -29,7 +30,7 @@ export class CommentsComponent implements OnInit, OnDestroy {
   viewOptionsService = inject(ViewOptionsService);
 
   readonly searchMatches = input<string[]>([]);
-  readonly textItemID = input<string>('');
+  readonly textKey = input.required<TextKey>();
   readonly openNewReadingTextView = output<string>();
   readonly setMobileModeActiveText = output<string>();
 
@@ -46,10 +47,10 @@ export class CommentsComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.mobileMode = this.platformService.isMobile();
 
-    if (this.textItemID()) {
-      this.loadCommentsText();
-      this.getCorrespondanceMetadata();
-    }
+    const textKey = this.textKey();
+    this.loadCommentsText(textKey);
+    this.getCorrespondanceMetadata(textKey);
+
     if (isBrowser()) {
       this.setUpTextListeners();
     }
@@ -59,8 +60,8 @@ export class CommentsComponent implements OnInit, OnDestroy {
     this.unlistenClickEvents?.();
   }
 
-  loadCommentsText() {
-    this.commentService.getComments(this.textItemID()).subscribe({
+  loadCommentsText(textKey: TextKey) {
+    this.commentService.getComments(textKey).subscribe({
       next: (text) => {
         if (text && String(text) !== 'File not found') {
           this.text = this.parserService.insertSearchMatchTags(String(text), this.searchMatches());
@@ -78,8 +79,8 @@ export class CommentsComponent implements OnInit, OnDestroy {
     });
   }
 
-  getCorrespondanceMetadata() {
-    this.commentService.getCorrespondanceMetadata(this.textItemID().split('_')[1]).subscribe(
+  getCorrespondanceMetadata(textKey: TextKey) {
+    this.commentService.getCorrespondanceMetadata(textKey.publicationID).subscribe(
       (text: any) => {
         if (text?.subjects?.length > 0) {
           const senders: string[] = [];

--- a/src/app/components/collection-text-types/facsimiles/facsimiles.component.ts
+++ b/src/app/components/collection-text-types/facsimiles/facsimiles.component.ts
@@ -7,6 +7,7 @@ import { config } from '@config';
 import { DraggableImageDirective } from '@directives/draggable-image.directive';
 import { FullscreenImageViewerModal } from '@modals/fullscreen-image-viewer/fullscreen-image-viewer.modal';
 import { Facsimile } from '@models/facsimile.model';
+import { TextKey } from '@models/collection.model';
 import { TrustHtmlPipe } from '@pipes/trust-html.pipe';
 import { CollectionContentService } from '@services/collection-content.service';
 import { PlatformService } from '@services/platform.service';
@@ -28,7 +29,7 @@ export class FacsimilesComponent implements OnInit {
   readonly facsID = input<number>();
   readonly imageNr = input<number>();
   readonly sortOrder = input<number>();
-  readonly textItemID = input<string>('');
+  readonly textKey = input.required<TextKey>();
   readonly selectedFacsID = output<number>();
   readonly selectedFacsName = output<string>();
   readonly selectedImageNr = output<number | null>();
@@ -61,20 +62,17 @@ export class FacsimilesComponent implements OnInit {
 
   ngOnInit() {
     this.mobileMode = this.platformService.isMobile();
-
-    if (this.textItemID()) {
-      this.loadFacsimiles();
-    }
+    this.loadFacsimiles(this.textKey());
   }
 
-  loadFacsimiles() {
-    this.collectionContentService.getFacsimiles(this.textItemID()).subscribe({
+  loadFacsimiles(textKey: TextKey) {
+    this.collectionContentService.getFacsimiles(textKey).subscribe({
       next: (facs) => {
         if (facs && facs.length > 0) {
-          const sectionId = this.textItemID().split('_')[2]?.split(';')[0]?.replace('ch', '') || '';
+          const sectionId = textKey.chapterID?.replace('ch', '') || '';
           for (const f of facs) {
             const facsimile = new Facsimile(f);
-            facsimile.itemId = this.textItemID();
+            facsimile.itemId = textKey.textItemID;
             facsimile.manuscript_id = f.publication_manuscript_id;
             if (!f['external_url']) {
               facsimile.title = f['title'];

--- a/src/app/components/collection-text-types/illustrations/illustrations.component.ts
+++ b/src/app/components/collection-text-types/illustrations/illustrations.component.ts
@@ -3,6 +3,7 @@ import { NgClass } from '@angular/common';
 import { IonicModule, ModalController } from '@ionic/angular';
 
 import { FullscreenImageViewerModal } from '@modals/fullscreen-image-viewer/fullscreen-image-viewer.modal';
+import { TextKey } from '@models/collection.model';
 import { HtmlParserService } from '@services/html-parser.service';
 import { PlatformService } from '@services/platform.service';
 import { ScrollService } from '@services/scroll.service';
@@ -21,7 +22,7 @@ export class IllustrationsComponent implements OnChanges, OnInit {
   private scrollService = inject(ScrollService);
 
   readonly singleImage = input<Record<string, any>>();
-  readonly textItemID = input<string>('');
+  readonly textKey = input.required<TextKey>();
   readonly showAllImages = output<any>();
   readonly setMobileModeActiveText = output<string>();
   
@@ -54,14 +55,11 @@ export class IllustrationsComponent implements OnChanges, OnInit {
 
   ngOnInit() {
     this.mobileMode = this.platformService.isMobile();
-
-    if (this.textItemID()) {
-      this.getIllustrationImages();
-    }
+    this.getIllustrationImages(this.textKey());
   }
 
-  private getIllustrationImages() {
-    this.parserService.getReadingTextIllustrations(this.textItemID()).subscribe(
+  private getIllustrationImages(textKey: TextKey) {
+    this.parserService.getReadingTextIllustrations(textKey).subscribe(
       (images: any[]) => {
         this.images = images;
         this.imageCountTotal = this.images.length;

--- a/src/app/components/collection-text-types/legend/legend.component.ts
+++ b/src/app/components/collection-text-types/legend/legend.component.ts
@@ -3,6 +3,7 @@ import { AsyncPipe } from '@angular/common';
 import { IonicModule } from '@ionic/angular';
 import { catchError, map, Observable, of } from 'rxjs';
 
+import { TextKey } from '@models/collection.model';
 import { TrustHtmlPipe } from '@pipes/trust-html.pipe';
 import { MarkdownService } from '@services/markdown.service';
 import { ScrollService } from '@services/scroll.service';
@@ -23,22 +24,20 @@ export class LegendComponent implements OnDestroy, OnInit {
   private scrollService = inject(ScrollService);
   private activeLocale = inject(LOCALE_ID);
 
-  readonly itemId = input<string>();
+  readonly textKey = input.required<TextKey>();
   readonly scrollToElementId = input<string>();
 
-  collectionId: string = '';
   intervalTimerId: number = 0;
-  publicationId: string = '';
   staticMdLegendFolderNumber: string = '13';
   text$: Observable<string>;
 
   private unlistenClickEvents?: () => void;
 
   ngOnInit() {
-    this.collectionId = this.itemId()?.split('_')[0] || '';
-    this.publicationId = this.itemId()?.split('_')[1].split(';')[0] || '';
+    const textKey = this.textKey();
+    const mdId = `${this.activeLocale}-${this.staticMdLegendFolderNumber}-${textKey.collectionID}-${textKey.publicationID}`;
+    this.text$ = this.getMdContent(mdId);
 
-    this.text$ = this.getMdContent(this.activeLocale + '-' + this.staticMdLegendFolderNumber + '-' + this.collectionId + '-' + this.publicationId);
     if (isBrowser()) {
       this.setUpTextListeners();
     }
@@ -58,7 +57,7 @@ export class LegendComponent implements OnDestroy, OnInit {
       }),
       catchError(e => {
         if (fileID.split('-').length > 3) {
-          return this.getMdContent(this.activeLocale + '-' + this.staticMdLegendFolderNumber + '-' + this.collectionId);
+          return this.getMdContent(this.activeLocale + '-' + this.staticMdLegendFolderNumber + '-' + this.textKey()?.collectionID);
         } else if (fileID.split('-')[2] !== '00') {
           return this.getMdContent(this.activeLocale + '-' + this.staticMdLegendFolderNumber + '-' + '00');
         } else {

--- a/src/app/components/collection-text-types/manuscripts/manuscripts.component.ts
+++ b/src/app/components/collection-text-types/manuscripts/manuscripts.component.ts
@@ -2,6 +2,7 @@ import { Component, ElementRef, OnInit, inject, output, input } from '@angular/c
 import { AlertButton, AlertController, AlertInput, IonicModule } from '@ionic/angular';
 
 import { config } from '@config';
+import { TextKey } from '@models/collection.model';
 import { TrustHtmlPipe } from '@pipes/trust-html.pipe';
 import { CollectionContentService } from '@services/collection-content.service';
 import { HtmlParserService } from '@services/html-parser.service';
@@ -25,7 +26,7 @@ export class ManuscriptsComponent implements OnInit {
 
   readonly msID = input<number>();
   readonly searchMatches = input<string[]>([]);
-  readonly textItemID = input<string>('');
+  readonly textKey = input.required<TextKey>();
   readonly openNewLegendView = output<any>();
   readonly openNewManView = output<any>();
   readonly selectedMsID = output<number>();
@@ -48,13 +49,11 @@ export class ManuscriptsComponent implements OnInit {
   }
 
   ngOnInit() {
-    if (this.textItemID()) {
-      this.loadManuscriptTexts();
-    }
+    this.loadManuscriptTexts(this.textKey());
   }
 
-  loadManuscriptTexts() {
-    this.collectionContentService.getManuscripts(this.textItemID()).subscribe({
+  loadManuscriptTexts(textKey: TextKey) {
+    this.collectionContentService.getManuscripts(textKey).subscribe({
       next: (res) => {
         if (
           res?.manuscripts?.length > 0 &&

--- a/src/app/components/collection-text-types/metadata/metadata.component.ts
+++ b/src/app/components/collection-text-types/metadata/metadata.component.ts
@@ -16,14 +16,14 @@ export class MetadataComponent implements OnInit {
   private collectionContentService = inject(CollectionContentService);
   private activeLocale = inject(LOCALE_ID);
 
-  readonly textItemID = input<string>('');
+  readonly publicationID = input.required<string>();
 
   loadingError$: Subject<boolean> = new Subject<boolean>();
   metadata$: Observable<any>;
 
   ngOnInit() {
     this.metadata$ = this.collectionContentService.getMetadata(
-      this.textItemID().split('_')[1] || '0', this.activeLocale
+      this.publicationID(), this.activeLocale
     ).pipe(
       catchError((error) => {
         console.error('Error loading metadata', error);

--- a/src/app/components/collection-text-types/variants/variants.component.ts
+++ b/src/app/components/collection-text-types/variants/variants.component.ts
@@ -2,6 +2,7 @@ import { Component, ElementRef, OnInit, inject, output, input } from '@angular/c
 import { AlertButton, AlertController, AlertInput, IonicModule } from '@ionic/angular';
 
 import { config } from '@config';
+import { TextKey } from '@models/collection.model';
 import { TrustHtmlPipe } from '@pipes/trust-html.pipe';
 import { CollectionContentService } from '@services/collection-content.service';
 import { HtmlParserService } from '@services/html-parser.service';
@@ -25,7 +26,7 @@ export class VariantsComponent implements OnInit {
 
   readonly searchMatches = input<Array<string>>([]);
   readonly sortOrder = input<number>();
-  readonly textItemID = input<string>('');
+  readonly textKey = input.required<TextKey>();
   readonly varID = input<number>();
   readonly openNewLegendView = output<any>();
   readonly openNewVarView = output<any>();
@@ -44,13 +45,11 @@ export class VariantsComponent implements OnInit {
   }
 
   ngOnInit() {
-    if (this.textItemID()) {
-      this.loadVariantTexts();
-    }
+    this.loadVariantTexts(this.textKey());
   }
 
-  loadVariantTexts() {
-    this.collectionContentService.getVariants(this.textItemID()).subscribe({
+  loadVariantTexts(textKey: TextKey) {
+    this.collectionContentService.getVariants(textKey).subscribe({
       next: (res) => {
         if (res?.variations?.length > 0) {
           this.variants = res.variations;

--- a/src/app/models/collection.model.ts
+++ b/src/app/models/collection.model.ts
@@ -1,0 +1,6 @@
+export type TextKey = Readonly<{
+  collectionID: string;
+  publicationID: string;
+  chapterID?: string;
+  textItemID: string;
+}>;

--- a/src/app/pages/collection/introduction/collection-introduction.page.ts
+++ b/src/app/pages/collection/introduction/collection-introduction.page.ts
@@ -861,7 +861,7 @@ export class CollectionIntroductionPage implements OnInit, OnDestroy {
   async showDownloadModal() {
     const modal = await this.modalCtrl.create({
       component: DownloadTextsModal,
-      componentProps: { origin: 'page-introduction', textItemID: this.collectionID }
+      componentProps: { origin: 'page-introduction', collectionId: this.collectionID }
     });
 
     modal.present();

--- a/src/app/pages/collection/text/collection-text.page.html
+++ b/src/app/pages/collection/text/collection-text.page.html
@@ -309,7 +309,7 @@
       @if (view.type === 'readingtext_' + lang) {
         <reading-text
               [language]="lang"
-              [textItemID]="textItemID"
+              [textKey]="textKey()"
               [textPosition]="textPosition"
               [searchMatches]="searchMatches"
               (openNewIllustrView)="openNewView($event)"
@@ -321,7 +321,7 @@
 
   @if (view.type === 'readingtext' && multilingualReadingTextLanguages.length < 2) {
     <reading-text
-          [textItemID]="textItemID"
+          [textKey]="textKey()"
           [textPosition]="textPosition"
           [searchMatches]="searchMatches"
           (openNewIllustrView)="openNewView($event)"
@@ -331,7 +331,7 @@
 
   @else if (view.type === 'comments') {
     <comments
-          [textItemID]="textItemID"
+          [textKey]="textKey()"
           [searchMatches]="searchMatches"
           (openNewReadingTextView)="openNewReadingTextShowCommentLemma($event)"
           (setMobileModeActiveText)="setActiveMobileModeViewType(undefined, $event)"
@@ -341,7 +341,7 @@
   @else if (view.type === 'facsimiles') {
     @defer (on immediate) {
       <facsimiles
-            [textItemID]="textItemID"
+            [textKey]="textKey()"
             [facsID]="view.id"
             [imageNr]="view.nr"
             [sortOrder]="view.sortOrder"
@@ -357,7 +357,7 @@
 
   @else if (view.type === 'manuscripts') {
     <manuscripts
-          [textItemID]="textItemID"
+          [textKey]="textKey()"
           [msID]="view.id"
           [searchMatches]="searchMatches"
           (selectedMsID)="updateViewProperty('id', $event, i)"
@@ -370,7 +370,7 @@
   @else if (view.type === 'variants') {
     @defer {
       <variants
-            [textItemID]="textItemID"
+            [textKey]="textKey()"
             [varID]="view.id"
             [searchMatches]="searchMatches"
             [sortOrder]="view.sortOrder"
@@ -389,7 +389,7 @@
     @defer {
       <illustrations
             [singleImage]="view.image"
-            [textItemID]="textItemID"
+            [textKey]="textKey()"
             (showAllImages)="updateIllustrationViewImage($event)"
             (setMobileModeActiveText)="setActiveMobileModeViewType(undefined, $event)"
       ></illustrations>
@@ -401,7 +401,7 @@
   @else if (view.type === 'legend') {
     @defer {
       <text-legend
-            [itemId]="textItemID"
+            [textKey]="textKey()"
             [scrollToElementId]="view.id"
       ></text-legend>
     } @loading (minimum 1s) {
@@ -410,7 +410,7 @@
   }
 
   @else if (view.type === 'metadata') {
-    <text-metadata [textItemID]="textItemID"></text-metadata>
+    <text-metadata [publicationID]="textKey().publicationID"></text-metadata>
   }
 </ng-template>
 

--- a/src/app/services/collection-content.service.ts
+++ b/src/app/services/collection-content.service.ts
@@ -3,6 +3,7 @@ import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 
 import { config } from '@config';
+import { TextKey } from '@models/collection.model';
 
 
 @Injectable({
@@ -24,84 +25,77 @@ export class CollectionContentService {
     this.apiURL = apiBaseURL + '/' + projectName;
   }
 
-  getTitle(id: string, language: string): Observable<any> {
-    const endpoint = `${this.apiURL}/text/${id}/1/tit/${language}`;
+  getTitle(collectionId: string, language: string): Observable<any> {
+    const endpoint = `${this.apiURL}/text/${collectionId}/1/tit/${language}`;
     return this.http.get(endpoint);
   }
 
-  getForeword(id: string, language: string): Observable<any> {
-    const endpoint = `${this.apiURL}/text/${id}/fore/${language}`;
+  getForeword(collectionId: string, language: string): Observable<any> {
+    const endpoint = `${this.apiURL}/text/${collectionId}/fore/${language}`;
     return this.http.get(endpoint);
   }
 
-  getIntroduction(id: string, language: string): Observable<any> {
-    const endpoint = `${this.apiURL}/text/${id}/1/inl/${language}`;
+  getIntroduction(collectionId: string, language: string): Observable<any> {
+    const endpoint = `${this.apiURL}/text/${collectionId}/1/inl/${language}`;
     return this.http.get(endpoint);
   }
 
-  getReadingText(id: string, language: string = ''): Observable<any> {
+  getReadingText(textKey: TextKey, language: string = ''): Observable<any> {
     const estFolder = language ? 'est-i18n' : 'est';
-    const idParts = id.split(';')[0].split('_');
-    const ch_id = idParts.length > 2 ? '/' + idParts[2] : '';
-    language = language ? '/' + language : '';
+    const ch_id = textKey.chapterID ? `/${textKey.chapterID}` : '';
+    const lang = language ? `/${language}` : '';
     const endpoint = `${this.apiURL}/text/`
-          + `${idParts[0]}/${idParts[1]}/${estFolder}${ch_id}${language}`;
+          + `${textKey.collectionID}/${textKey.publicationID}/${estFolder}${ch_id}${lang}`;
     return this.http.get(endpoint);
   }
 
-  getManuscripts(id: string, ms_id?: number | string): Observable<any> {
-    const idParts = id.split(';')[0].split('_');
-    const ch_id = idParts.length > 2 ? '/' + idParts[2] : '';
+  getManuscripts(textKey: TextKey, ms_id?: number | string): Observable<any> {
+    const ch_id = textKey.chapterID ? `/${textKey.chapterID}` : '';
     ms_id = ms_id ? '/' + ms_id : '';
-    const endpoint = `${this.apiURL}/text/${idParts[0]}/${idParts[1]}/ms${ms_id}${ch_id}`;
+    const endpoint = `${this.apiURL}/text/${textKey.collectionID}/${textKey.publicationID}/ms${ms_id}${ch_id}`;
     return this.http.get(endpoint);
   }
 
-  getManuscriptsList(id: string): Observable<any> {
-    const idParts = id.split(';')[0].split('_');
-    const endpoint = `${this.apiURL}/text/${idParts[0]}/${idParts[1]}/list/ms`;
+  getManuscriptsList(textKey: TextKey): Observable<any> {
+    const endpoint = `${this.apiURL}/text/${textKey.collectionID}/${textKey.publicationID}/list/ms`;
     return this.http.get(endpoint);
   }
 
-  getVariants(id: string): Observable<any> {
-    const idParts = id.split(';')[0].split('_');
-    const ch_id = idParts.length > 2 ? '/' + idParts[2] : '';
-    const endpoint = `${this.apiURL}/text/${idParts[0]}/${idParts[1]}/var${ch_id}`;
+  getVariants(textKey: TextKey): Observable<any> {
+    const ch_id = textKey.chapterID ? `/${textKey.chapterID}` : '';
+    const endpoint = `${this.apiURL}/text/${textKey.collectionID}/${textKey.publicationID}/var${ch_id}`;
     return this.http.get(endpoint);
   }
 
-  getFacsimiles(id: string): Observable<any> {
-    const idParts = id.split(';')[0].split('_');
-    const ch_id = idParts.length > 2 ? '/' + idParts[2].replace('ch', '') : '';
-    const endpoint = `${this.apiURL}/facsimiles/${idParts[1]}${ch_id}`;
+  getFacsimiles(textKey: TextKey): Observable<any> {
+    const ch_id = textKey.chapterID ? `/${textKey.chapterID.replace('ch', '')}` : '';
+    const endpoint = `${this.apiURL}/facsimiles/${textKey.publicationID}${ch_id}`;
     return this.http.get(endpoint);
   }
 
-  getMetadata(pub_id: string, language: string): Observable<any> {
-    const endpoint = `${this.apiURL}/publications/${pub_id}/metadata/${language}`;
+  getMetadata(publicationId: string, language: string): Observable<any> {
+    const endpoint = `${this.apiURL}/publications/${publicationId}/metadata/${language}`;
     return this.http.get(endpoint);
   }
 
-  getDownloadableIntroduction(id: string, format: string, language: string): Observable<any> {
-    const endpoint = `${this.apiURL}/text/downloadable/${format}/${id}/inl/${language}`;
+  getDownloadableIntroduction(collectionId: string, format: string, language: string): Observable<any> {
+    const endpoint = `${this.apiURL}/text/downloadable/${format}/${collectionId}/inl/${language}`;
     return this.http.get(endpoint);
   }
 
-  getDownloadableReadingText(id: string, format: string, language: string = ''): Observable<any> {
+  getDownloadableReadingText(textKey: TextKey, format: string, language: string = ''): Observable<any> {
     const estFolder = language ? 'est-i18n' : 'est';
-    const idParts = id.split(';')[0].split('_');
-    const ch_id = idParts.length > 2 ? '/' + idParts[2] : '';
-    language = language ? '/' + language : '';
+    const ch_id = textKey.chapterID ? `/${textKey.chapterID}` : '';
+    const lang = language ? `/${language}` : '';
     const endpoint = `${this.apiURL}/text/downloadable/`
-          + `${format}/${idParts[0]}/${idParts[1]}/${estFolder}${ch_id}${language}`;
+          + `${format}/${textKey.collectionID}/${textKey.publicationID}/${estFolder}${ch_id}${lang}`;
     return this.http.get(endpoint);
   }
 
-  getDownloadableManuscript(id: string, msID: number, format: string): Observable<any> {
-    const idParts = id.split(';')[0].split('_');
-    const ch_id = idParts.length > 2 ? '/' + idParts[2] : '';
+  getDownloadableManuscript(textKey: TextKey, msID: number, format: string): Observable<any> {
+    const ch_id = textKey.chapterID ? `/${textKey.chapterID}` : '';
     const endpoint = `${this.apiURL}/text/downloadable/`
-          + `${format}/${idParts[0]}/${idParts[1]}/ms/${msID}${ch_id}`;
+          + `${format}/${textKey.collectionID}/${textKey.publicationID}/ms/${msID}${ch_id}`;
     return this.http.get(endpoint);
   }
 

--- a/src/app/services/html-parser.service.ts
+++ b/src/app/services/html-parser.service.ts
@@ -7,6 +7,7 @@ import { render } from 'dom-serializer';
 
 import { config } from '@config';
 import { HeadingNode } from '@models/article.model';
+import { TextKey } from '@models/collection.model';
 import { CollectionContentService } from '@services/collection-content.service';
 
 
@@ -71,8 +72,8 @@ export class HtmlParserService {
     return text;
   }
 
-  getReadingTextIllustrations(id: string): Observable<any> {
-    return this.collectionContentService.getReadingText(id).pipe(
+  getReadingTextIllustrations(textKey: TextKey): Observable<any> {
+    return this.collectionContentService.getReadingText(textKey).pipe(
       map((res) => {
         const images: any[] = [];
         if (
@@ -81,7 +82,7 @@ export class HtmlParserService {
           res.content !== '<html xmlns="http://www.w3.org/1999/xhtml"><head></head><body>File not found</body></html>'
         ) {
           const _apiURL = this.apiURL;
-          const collectionID = String(id).split('_')[0];
+          const collectionID = textKey.collectionID;
           let text = res.content as string;
           text = this.postprocessReadingText(text, collectionID);
 

--- a/src/app/services/tooltip.service.ts
+++ b/src/app/services/tooltip.service.ts
@@ -2,6 +2,7 @@ import { Injectable, inject } from '@angular/core';
 import { catchError, map, Observable, of } from 'rxjs';
 
 import { config } from '@config';
+import { TextKey } from '@models/collection.model';
 import { CommentService } from '@services/comment.service';
 import { NamedEntityService } from '@services/named-entity.service';
 import { PlatformService } from '@services/platform.service';
@@ -90,7 +91,7 @@ export class TooltipService {
    * <img src=".." data-id="en5929">
    * <span class="tooltip"></span>
    */
-  getCommentTooltip(textItemID: string, elementID: string): Observable<any> {
+  getCommentTooltip(textKey: TextKey, elementID: string): Observable<any> {
     elementID = elementID.replace('end', 'en');
     const cachedTooltip = this.cachedTooltips.comments.has(elementID)
       ? this.cachedTooltips.comments.get(elementID) : '';
@@ -99,7 +100,7 @@ export class TooltipService {
       return of({ name: 'Comment', description: cachedTooltip });
     }
 
-    return this.commentService.getSingleComment(textItemID, elementID).pipe(
+    return this.commentService.getSingleComment(textKey, elementID).pipe(
       map((comment: any) => {
         this.cachedTooltips.comments.size > this.maxTooltipCacheSize && this.cachedTooltips.comments.clear();
         !this.platformService.isMobile() && this.cachedTooltips.comments.set(elementID, comment);


### PR DESCRIPTION
Instead of passing a string consisting of the current collection, publication and optional chapter id to dependent components, pass an object (TextKey) holding the properties.