### PR TITLE
fix(auth): protect the `content` route with `authGuard` and derive si…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Fixed
 
 - Translations.
+- Auth: protect the `content` route with `authGuard` and derive sitemap auth-protected route exclusions from the canonical route definitions.
 
 
 

--- a/prebuild-generate-routes.js
+++ b/prebuild-generate-routes.js
@@ -285,6 +285,12 @@ function getAuthProtectedRoutePaths(routeBlocks, authEnabled) {
   return extractAuthProtectedRoutePaths(routeBlocks);
 }
 
+function getAuthProtectedRoutePathsFromSourceFile(routesFilepath, authEnabled) {
+  const sourceContent = fs.readFileSync(path.join(__dirname, routesFilepath), 'utf-8');
+  const routeBlocks = extractRouteBlocks(sourceContent);
+  return getAuthProtectedRoutePaths(routeBlocks, authEnabled);
+}
+
 function extractAuthProtectedRoutePaths(routeBlocks) {
   const paths = routeBlocks
     .filter(isAuthProtectedRouteBlock)
@@ -451,6 +457,7 @@ module.exports = {
   getRoutePath,
   stripCommentsPreserveLiterals,
   getAuthProtectedRoutePaths,
+  getAuthProtectedRoutePathsFromSourceFile,
   extractAuthProtectedRoutePaths,
   isAuthProtectedRouteBlock
 };

--- a/prebuild-generate-sitemap.js
+++ b/prebuild-generate-sitemap.js
@@ -1,8 +1,12 @@
 const fs = require('fs');
 const path = require('path');
 const common = require('./prebuild-common-fns');
+const {
+  getAuthProtectedRoutePathsFromSourceFile
+} = require('./prebuild-generate-routes');
 
 const configFilepath = 'src/assets/config/config.ts';
+const routesFilepath = 'src/app/app.routes.ts';
 const sitemapFilename = 'sitemap.txt';
 const SITEMAP_EXCLUDED_ROUTE_PATH_KEYS = Object.freeze([
   'login',
@@ -12,16 +16,6 @@ const SITEMAP_EXCLUDED_ROUTE_PATH_KEYS = Object.freeze([
   'change-password',
   'register',
   'verify-email'
-]);
-const AUTH_PROTECTED_ROUTE_PATH_KEYS = Object.freeze([
-  'collection/:collectionID/cover',
-  'collection/:collectionID/title',
-  'collection/:collectionID/foreword',
-  'collection/:collectionID/introduction',
-  'collection/:collectionID/text',
-  'index/:type',
-  'media-collection',
-  'search'
 ]);
 
 generateSitemap();
@@ -187,11 +181,19 @@ function getSitemapRouteIncludeByPath(routeIncludeByPath, authEnabled) {
     return includeByPath;
   }
 
-  for (const routePathKey of AUTH_PROTECTED_ROUTE_PATH_KEYS) {
+  for (const routePathKey of getAuthProtectedRoutePathKeys(authEnabled)) {
     includeByPath[routePathKey] = false;
   }
 
   return includeByPath;
+}
+
+function getAuthProtectedRoutePathKeys(authEnabled) {
+  if (!authEnabled) {
+    return [];
+  }
+
+  return getAuthProtectedRoutePathsFromSourceFile(routesFilepath, authEnabled);
 }
 
 function initializeSitemapFile(urlOrigin, locale) {

--- a/scripts/test-prebuild-generate-routes.js
+++ b/scripts/test-prebuild-generate-routes.js
@@ -186,6 +186,15 @@ test('current app.routes.ts yields no protected paths when auth is disabled', ()
   assert.deepStrictEqual(paths, []);
 });
 
+test('current app.routes.ts includes content in protected paths when auth is enabled', () => {
+  const routesPath = path.join(__dirname, '../src/app/app.routes.ts');
+  const source = fs.readFileSync(routesPath, 'utf-8');
+  const blocks = extractRouteBlocks(source);
+  const paths = getAuthProtectedRoutePaths(blocks, true);
+
+  assert.ok(paths.includes('content'));
+});
+
 let passed = 0;
 for (const { name, fn } of tests) {
   try {

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -47,7 +47,8 @@ export const routes: Routes = [
   },
   {
     path: 'content',
-    loadChildren: () => import('./pages/content/content.module').then(m => m.ContentPageModule)
+    loadChildren: () => import('./pages/content/content.module').then(m => m.ContentPageModule),
+    canActivate: [authGuard]
   },
   {
     path: 'collection/:collectionID/cover',


### PR DESCRIPTION
…temap auth-protected route exclusions from the canonical route definitions