### PR TITLE
fix(ssr): keep canonical and Open Graph URLs on the configured HTTPS …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- SSR: keep canonical and Open Graph URLs on the configured HTTPS origin when the app is deployed behind an internal HTTP proxy hop.
+
 
 
 ## [2.7.5] – 2026-06-18

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -49,6 +49,8 @@ The request IP used by the limiter depends on Express proxy trust settings. Conf
 
 - `app.ssr.trustProxyHops` (default: `2`): number of trusted proxy hops when resolving `req.ip` for SSR rate limiting. Value `2` is correct when the app runs behind one upstream reverse proxy (for example HAProxy) in front of nginx (`reverse proxy -> nginx -> Node/Express SSR app`). If the app is reached directly through nginx (no extra reverse proxy), set this to `1`. If the app is reached directly by Node/Express (no proxy), set this to `0`. If the proxy chain is longer, increase the value accordingly.
 
+The nginx config preserves an incoming `X-Forwarded-Proto` header when the app runs behind an upstream TLS-terminating proxy, and falls back to nginx's own `$scheme` when that header is absent. SSR URL generation also treats `app.siteURLOrigin` as authoritative when the request host matches the configured public host, so canonical and Open Graph URLs keep the configured HTTPS origin even if an internal proxy hop uses HTTP.
+
 **Important!** nginx gets access to the static files through a [Docker volume][docker_volume_reference], which is defined in [`compose.yml`][docker_compose_file]. Since volumes persist even if the container itself is deleted, and the content of a volume is not updated when the image is updated, you need to run
 
 ```

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,3 +1,12 @@
+#
+# Preserve the original public request protocol when an upstream TLS-terminating
+# proxy forwards requests to this nginx instance over HTTP. If no forwarded
+# protocol is present, fall back to nginx's own scheme.
+map $http_x_forwarded_proto $proxy_x_forwarded_proto {
+  default $http_x_forwarded_proto;
+  "" $scheme;
+}
+
 upstream nodejs {
   server web:4201;
 }
@@ -62,9 +71,10 @@ server {
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $http_host;
+    proxy_set_header X-Forwarded-Host $http_host;
     proxy_set_header X-NginX-Proxy true;
     proxy_redirect off;
-    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
     proxy_buffers 24 16k; # total buffer space = 384 KB per request
     proxy_buffer_size 16k; # buffer size for headers
   }

--- a/scripts/test-ssr-smoke.js
+++ b/scripts/test-ssr-smoke.js
@@ -285,6 +285,32 @@ const TEST_CASES = [
       },
     ],
   },
+  {
+    name: 'SEO tags prefer configured HTTPS origin for public host',
+    route: '/sv/collection/219/text/19443',
+    headers: {
+      Host: 'topelius.sls.fi',
+      'X-Forwarded-Host': 'topelius.sls.fi',
+      'X-Forwarded-Proto': 'http',
+    },
+    checks: [
+      {
+        description: 'Canonical link keeps configured https origin',
+        type: 'includes',
+        value: '<link rel="canonical" href="https://topelius.sls.fi/sv/collection/219/text/19443">',
+      },
+      {
+        description: 'og:url keeps configured https origin',
+        type: 'includes',
+        value: '<meta property="og:url" content="https://topelius.sls.fi/sv/collection/219/text/19443">',
+      },
+      {
+        description: 'og:image keeps configured https origin',
+        type: 'includes',
+        value: '<meta property="og:image" content="https://topelius.sls.fi/sv/assets/images/',
+      },
+    ],
+  },
 ];
 
 function printHelp() {

--- a/server.ts
+++ b/server.ts
@@ -16,6 +16,7 @@ import { environment } from './src/environments/environment';
 import { REQUEST } from './src/express.tokens';
 import { config } from './src/assets/config/config';
 import { authProtectedRoutePaths } from './src/app/auth-protected-route-paths.generated';
+import { getConfiguredSiteHostname, getRequestRenderUrl } from './src/app/utils/request-origin';
 
 const LOOPBACK_ALLOWED_HOSTS = ['localhost', '127.0.0.1', '[::1]'] as const;
 
@@ -28,29 +29,9 @@ const SSR_TRUST_PROXY_HOPS = getNonNegativeInt(config?.app?.ssr?.trustProxyHops,
 const authEnabled = config?.app?.auth?.enabled === true;
 const authProtectedRouteSegmentPatterns = authProtectedRoutePaths.map((routePath) => toRouteSegments(routePath));
 
-/**
- * Resolves a hostname from `config.app.siteURLOrigin` for SSR host validation.
- */
-function getConfiguredAllowedHost(): string | undefined {
-  const siteURLOrigin = config?.app?.siteURLOrigin;
-  if (typeof siteURLOrigin !== 'string' || siteURLOrigin.trim().length === 0) {
-    return undefined;
-  }
-
-  const normalizedOrigin = /^[a-zA-Z][a-zA-Z\d+\-.]*:\/\//.test(siteURLOrigin)
-    ? siteURLOrigin
-    : `https://${siteURLOrigin}`;
-
-  try {
-    return new URL(normalizedOrigin).hostname.toLowerCase();
-  } catch {
-    return undefined;
-  }
-}
-
 function getAllowedHosts(): string[] {
   const allowedHosts = new Set<string>(LOOPBACK_ALLOWED_HOSTS);
-  const configuredHost = getConfiguredAllowedHost();
+  const configuredHost = getConfiguredSiteHostname();
   if (configuredHost) {
     allowedHosts.add(configuredHost);
   }
@@ -209,7 +190,7 @@ export function app(lang: string): express.Express {
   // Catch-all route: render Angular app for non-static paths (SSR or client-side routes, including 404 pages)
   server.use(renderRequestRateLimiter, (req, res, next) => {
     // console.log(`[SSR] Rendering URL: ${req.url}`);
-    const { protocol, originalUrl, baseUrl, headers } = req;
+    const { baseUrl } = req;
     // Temporary request debug snippet (keep commented unless troubleshooting):
     // const forwardedForHeader = req.headers['x-forwarded-for'];
     // const forwardedFor = Array.isArray(forwardedForHeader)
@@ -232,7 +213,7 @@ export function app(lang: string): express.Express {
       .render({
         bootstrap: AppServerModule,
         documentFilePath: indexHtml,
-        url: `${protocol}://${headers.host}${originalUrl}`,
+        url: getRequestRenderUrl(req),
         inlineCriticalCss: false,
         publicPath: browserDistFolder,
         providers: [

--- a/src/app/services/document-head.service.ts
+++ b/src/app/services/document-head.service.ts
@@ -1,11 +1,12 @@
 import { Injectable, LOCALE_ID, OnDestroy, Renderer2, RendererFactory2, DOCUMENT, inject } from '@angular/core';
 import { Meta, Title } from '@angular/platform-browser';
 import { BehaviorSubject, Observable } from 'rxjs';
-import { Request } from 'express';
+import type { Request } from 'express';
 
 import { config } from '@config';
 import { RouteLocalizationService } from '@services/route-localization.service';
 import { REQUEST } from 'src/express.tokens';
+import { getConfiguredSiteOrigin, getRequestOrigin } from '../utils/request-origin';
 
 
 @Injectable({
@@ -299,50 +300,11 @@ export class DocumentHeadService implements OnDestroy {
    * @returns Origin string (`scheme://host`).
    */
   private getOrigin(): string {
-    const requestOrigin = this.getRequestOrigin();
+    const requestOrigin = getRequestOrigin(this.request);
     if (requestOrigin) {
       return requestOrigin;
     }
-    return String(this.document.defaultView?.location.origin ?? config.app?.siteURLOrigin ?? '');
-  }
-
-  /**
-   * Builds an origin from SSR request headers when available.
-   * @returns Origin derived from request metadata.
-   */
-  private getRequestOrigin(): string | undefined {
-    if (!this.request) {
-      return undefined;
-    }
-
-    const host = this.getRequestHeaderValue('x-forwarded-host')
-      || this.getRequestHeaderValue('host');
-
-    if (!host) {
-      return undefined;
-    }
-
-    const protocol = this.getRequestHeaderValue('x-forwarded-proto')
-      || (!this.isLocalHost(host) ? this.getConfiguredOriginProtocol() : undefined)
-      || this.request.protocol
-      || 'http';
-
-    return protocol + '://' + host;
-  }
-
-  /**
-   * Returns the first normalized value of a request header.
-   * @param headerName Request header name.
-   * @returns Header value if present.
-   */
-  private getRequestHeaderValue(headerName: string): string | undefined {
-    const header = this.request?.headers?.[headerName];
-    if (!header) {
-      return undefined;
-    }
-    const firstValue = Array.isArray(header) ? header[0] : header;
-    const normalizedValue = String(firstValue).split(',')[0]?.trim();
-    return normalizedValue || undefined;
+    return String(this.document.defaultView?.location.origin ?? getConfiguredSiteOrigin() ?? '');
   }
 
   /**
@@ -372,37 +334,6 @@ export class DocumentHeadService implements OnDestroy {
     }
 
     return normalizedPath;
-  }
-
-  /**
-   * Extracts protocol from `config.app.siteURLOrigin`.
-   * @returns Protocol name without trailing colon.
-   */
-  private getConfiguredOriginProtocol(): string | undefined {
-    const configuredOrigin = config.app?.siteURLOrigin;
-    if (!configuredOrigin) {
-      return undefined;
-    }
-
-    try {
-      return new URL(configuredOrigin).protocol.replace(':', '');
-    } catch {
-      return undefined;
-    }
-  }
-
-  /**
-   * Checks whether a host points to localhost.
-   * @param host Host string, optionally including port.
-   * @returns True for localhost and loopback addresses.
-   */
-  private isLocalHost(host: string): boolean {
-    const hostname = host.split(':')[0].toLowerCase();
-    return (
-      hostname === 'localhost' ||
-      hostname === '127.0.0.1' ||
-      hostname === '::1'
-    );
   }
 
   /**

--- a/src/app/utils/request-origin.ts
+++ b/src/app/utils/request-origin.ts
@@ -1,0 +1,170 @@
+import type { Request } from 'express';
+
+import { config } from '../../assets/config/config';
+
+
+/**
+ * Helpers for resolving the public origin used by SSR.
+ *
+ * The app is commonly deployed behind a TLS-terminating proxy in front of
+ * nginx, while nginx talks to Node/Express over plain HTTP. In that setup,
+ * Express can see an internal HTTP request even though the public page URL is
+ * HTTPS. SEO tags and Angular's SSR document location must use the public
+ * origin, not the internal proxy hop.
+ *
+ * `app.siteURLOrigin` is treated as authoritative when the incoming request
+ * host matches the configured public host. This keeps canonical/Open Graph
+ * URLs stable even if a proxy overwrites or omits `X-Forwarded-Proto`.
+ */
+type OriginRequest = Pick<Request, 'headers' | 'protocol'>;
+type RenderRequest = OriginRequest & Pick<Request, 'originalUrl'>;
+
+const URL_SCHEME_PATTERN = /^[a-zA-Z][a-zA-Z\d+\-.]*:\/\//;
+
+/**
+ * Resolves the configured public site origin, normalizing host-only values to HTTPS.
+ * This is the canonical origin configured by each edition/fork.
+ */
+export function getConfiguredSiteOrigin(): string | undefined {
+  const siteURLOrigin = config?.app?.siteURLOrigin;
+  if (typeof siteURLOrigin !== 'string' || siteURLOrigin.trim().length === 0) {
+    return undefined;
+  }
+
+  const normalizedOrigin = URL_SCHEME_PATTERN.test(siteURLOrigin)
+    ? siteURLOrigin
+    : `https://${siteURLOrigin}`;
+
+  try {
+    return new URL(normalizedOrigin).origin;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Resolves the configured public site hostname.
+ * Used for host allow-listing and for matching requests to the configured
+ * public origin without considering protocol or port.
+ */
+export function getConfiguredSiteHostname(): string | undefined {
+  const configuredOrigin = getConfiguredSiteOrigin();
+  if (!configuredOrigin) {
+    return undefined;
+  }
+
+  try {
+    return new URL(configuredOrigin).hostname.toLowerCase();
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Builds the public origin for an SSR request.
+ *
+ * If the request host is the configured public host, the configured origin wins
+ * over forwarded protocol headers from an internal HTTP proxy hop.
+ *
+ * For unknown hosts, the resolver keeps the existing dynamic behavior:
+ * forwarded host/protocol headers are used when present, non-local requests
+ * fall back to the configured protocol, and local development falls back to
+ * Express' request protocol.
+ */
+export function getRequestOrigin(request?: OriginRequest | null): string | undefined {
+  if (!request) {
+    return undefined;
+  }
+
+  const host = getRequestHeaderValue(request, 'x-forwarded-host')
+    || getRequestHeaderValue(request, 'host');
+
+  if (!host) {
+    return undefined;
+  }
+
+  const configuredOriginForHost = getConfiguredSiteOriginForHost(host);
+  if (configuredOriginForHost) {
+    return configuredOriginForHost;
+  }
+
+  const protocol = getRequestHeaderValue(request, 'x-forwarded-proto')
+    || (!isLocalHost(host) ? getConfiguredSiteProtocol() : undefined)
+    || request.protocol
+    || 'http';
+
+  return `${protocol}://${host}`;
+}
+
+/**
+ * Builds the absolute URL passed to Angular SSR for one request.
+ *
+ * Angular uses this URL to populate the server-side document location. The
+ * document location is then consumed by metadata helpers that generate
+ * canonical and Open Graph URLs, so this must be the public URL.
+ */
+export function getRequestRenderUrl(request: RenderRequest): string {
+  const origin = getRequestOrigin(request);
+  if (origin) {
+    return `${origin}${request.originalUrl}`;
+  }
+
+  const protocol = request.protocol || 'http';
+  const host = getRequestHeaderValue(request, 'host') || 'localhost';
+  return `${protocol}://${host}${request.originalUrl}`;
+}
+
+function getConfiguredSiteOriginForHost(host: string): string | undefined {
+  const configuredOrigin = getConfiguredSiteOrigin();
+  const configuredHostname = getConfiguredSiteHostname();
+  const requestHostname = getHostname(host);
+
+  return configuredOrigin && configuredHostname && requestHostname === configuredHostname
+    ? configuredOrigin
+    : undefined;
+}
+
+function getConfiguredSiteProtocol(): string | undefined {
+  const configuredOrigin = getConfiguredSiteOrigin();
+  if (!configuredOrigin) {
+    return undefined;
+  }
+
+  try {
+    return new URL(configuredOrigin).protocol.replace(':', '');
+  } catch {
+    return undefined;
+  }
+}
+
+function getRequestHeaderValue(request: OriginRequest, headerName: string): string | undefined {
+  const header = request.headers?.[headerName.toLowerCase()];
+  if (!header) {
+    return undefined;
+  }
+  const firstValue = Array.isArray(header) ? header[0] : header;
+  const normalizedValue = String(firstValue).split(',')[0]?.trim();
+  return normalizedValue || undefined;
+}
+
+function isLocalHost(host: string): boolean {
+  const hostname = getHostname(host);
+  return (
+    hostname === 'localhost' ||
+    hostname === '127.0.0.1' ||
+    hostname === '::1' ||
+    hostname === '[::1]'
+  );
+}
+
+function getHostname(hostOrOrigin: string): string | undefined {
+  const normalizedHostOrOrigin = URL_SCHEME_PATTERN.test(hostOrOrigin)
+    ? hostOrOrigin
+    : `http://${hostOrOrigin}`;
+
+  try {
+    return new URL(normalizedHostOrOrigin).hostname.toLowerCase();
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
…origin when the app is deployed behind an internal HTTP proxy hop